### PR TITLE
Finalize language selector

### DIFF
--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsDownloadPermissionsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsDownloadPermissionsViewModel.kt
@@ -18,7 +18,9 @@ class AdministratorControlsDownloadPermissionsViewModel(
   private val userProfileId: ProfileId,
   deviceSettings: DeviceSettings
 ) : AdministratorControlsItemViewModel() {
-  /** [Boolean] observable value showing if topic downloads and updates should happen only on Wifi. */
+  /**
+   * [Boolean] observable value showing if topic downloads and updates should happen only on Wifi.
+   */
   val isTopicWifiUpdatePermission =
     ObservableField<Boolean>(deviceSettings.allowDownloadAndUpdateOnlyOnWifi)
   /** [Boolean] observable value showing if topic updates should happen automatically. */

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsItemViewModel.kt
@@ -3,7 +3,10 @@ package org.oppia.android.app.administratorcontrols.administratorcontrolsitemvie
 import androidx.databinding.ObservableField
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** Super-class for generalising different views for the recyclerView in [AdministratorControlsFragment] */
+/**
+ * Super-class for generalising different views for the recyclerView in
+ * [AdministratorControlsFragment].
+ */
 abstract class AdministratorControlsItemViewModel : ObservableViewModel() {
   /** [Boolean] observable value showing if [View] is multipane. */
   val isMultipane = ObservableField<Boolean>(false)

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsProfileViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsProfileViewModel.kt
@@ -9,7 +9,7 @@ class AdministratorControlsProfileViewModel(
   private val loadProfileListListener: LoadProfileListListener
 ) : AdministratorControlsItemViewModel() {
 
-  /** Called when user clicks on EditProfiles in [AdministratorControlsActivity]. */
+  /** Called when a user clicks on EditProfiles in [AdministratorControlsActivity]. */
   fun onEditProfilesClicked() {
     if (isMultipane.get()!!) {
       loadProfileListListener.loadProfileList()

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -10,7 +10,7 @@ import org.oppia.android.app.utility.getVersionName
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import javax.inject.Inject
 
-/** [ViewModel] for [AppVersionFragment] */
+/** [ViewModel] for [AppVersionFragment]. */
 @FragmentScope
 class AppVersionViewModel @Inject constructor(
   private val resourceHandler: AppLanguageResourceHandler,

--- a/app/src/main/java/org/oppia/android/app/customview/SegmentedCircularProgressView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/SegmentedCircularProgressView.kt
@@ -25,7 +25,11 @@ private const val STROKE_DASH_GAP_IN_DEGREE = 12
  *
  * Reference: // https://stackoverflow.com/a/39210676
  */
-class SegmentedCircularProgressView : View {
+class SegmentedCircularProgressView @JvmOverloads constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+  defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
   @Inject
   lateinit var resourceHandler: AppLanguageResourceHandler
 
@@ -62,23 +66,6 @@ class SegmentedCircularProgressView : View {
       initialise()
     }
   }
-
-  /** Constructor for creating an instance of this view.
-   * @param context */
-  constructor(context: Context) : super(context)
-  /** Constructor for creating an instance of this view.
-   * @param context
-   * @param attrs */
-  constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
-  /** Constructor for creating an instance of this view.
-   * @param context
-   * @param attrs
-   * @param defStyleAttr */
-  constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(
-    context,
-    attrs,
-    defStyleAttr
-  )
 
   private fun initialise() {
     chaptersNotStarted = totalChapters - chaptersFinished - chaptersInProgress

--- a/app/src/main/java/org/oppia/android/app/devoptions/DeveloperOptionsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/devoptions/DeveloperOptionsActivity.kt
@@ -80,7 +80,7 @@ class DeveloperOptionsActivity :
   }
 
   companion object {
-    /** Function to create intent for DeveloperOptionsActivity */
+    /** Function to create intent for DeveloperOptionsActivity. */
     fun createDeveloperOptionsActivityIntent(context: Context, internalProfileId: Int): Intent {
       return Intent(context, DeveloperOptionsActivity::class.java).apply {
         putExtra(NAVIGATION_PROFILE_ID_ARGUMENT_KEY, internalProfileId)

--- a/app/src/main/java/org/oppia/android/app/help/LoadFaqListFragmentListener.kt
+++ b/app/src/main/java/org/oppia/android/app/help/LoadFaqListFragmentListener.kt
@@ -2,6 +2,6 @@ package org.oppia.android.app.help
 
 /** Listener for when a selection should result to [FAQListFragment] in tablet devices. */
 interface LoadFaqListFragmentListener {
-  /**  Called when the user wants to open the list of FAQs in tablet devices. */
+  /** Called when the user wants to open the list of FAQs in tablet devices. */
   fun loadFaqListFragment()
 }

--- a/app/src/main/java/org/oppia/android/app/help/LoadPoliciesFragmentListener.kt
+++ b/app/src/main/java/org/oppia/android/app/help/LoadPoliciesFragmentListener.kt
@@ -7,6 +7,6 @@ import org.oppia.android.app.model.PolicyPage
  * on tablet.
  */
 interface LoadPoliciesFragmentListener {
-  /**  Called when the user wants to view an app policy. */
+  /** Called when the user wants to view an app policy. */
   fun loadPoliciesFragment(policyPage: PolicyPage)
 }

--- a/app/src/main/java/org/oppia/android/app/help/LoadThirdPartyDependencyListFragmentListener.kt
+++ b/app/src/main/java/org/oppia/android/app/help/LoadThirdPartyDependencyListFragmentListener.kt
@@ -5,6 +5,6 @@ package org.oppia.android.app.help
  * devices.
  */
 interface LoadThirdPartyDependencyListFragmentListener {
-  /**  Called when the user wants to open the list of third-party dependencies in tablet devices. */
+  /** Called when the user wants to open the list of third-party dependencies in tablet devices. */
   fun loadThirdPartyDependencyListFragment()
 }

--- a/app/src/main/java/org/oppia/android/app/help/RouteToThirdPartyDependencyListListener.kt
+++ b/app/src/main/java/org/oppia/android/app/help/RouteToThirdPartyDependencyListListener.kt
@@ -2,6 +2,6 @@ package org.oppia.android.app.help
 
 /** Listener for when a selection should result to [ThirdPartyDependencyListActivity]. */
 interface RouteToThirdPartyDependencyListListener {
-  /**  Called when the user wants to open the list of third-party dependencies. */
+  /** Called when the user wants to open the list of third-party dependencies. */
   fun onRouteToThirdPartyDependencyList()
 }

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/ExpandedHintListIndexListener.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/ExpandedHintListIndexListener.kt
@@ -6,12 +6,12 @@ package org.oppia.android.app.hintsandsolution
  */
 interface ExpandedHintListIndexListener {
 
-  /** Manage expanded list icon */
+  /** Manage expanded list icon. */
   fun onExpandListIconClicked(expandedItemsList: ArrayList<Int>)
 
-  /** Manage reveal hint button visibility while orientation change */
+  /** Manage reveal hint button visibility while orientation change. */
   fun onRevealHintClicked(index: Int?, isHintRevealed: Boolean?)
 
-  /** Manage reveal solution button visibility while orientation change */
+  /** Manage reveal solution button visibility while orientation change. */
   fun onRevealSolutionClicked(solutionIndex: Int?, isSolutionRevealed: Boolean?)
 }

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionListener.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionListener.kt
@@ -1,6 +1,6 @@
 package org.oppia.android.app.hintsandsolution
 
-/** Allows parent activity to dismiss the [HintsAndSolutionFragmentt] */
+/** Allows parent activity to dismiss the [HintsAndSolutionFragment]. */
 interface HintsAndSolutionListener {
   /** Called when the hints and solution dialog should be dismissed. */
   fun dismiss()

--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/PromotedStoryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/PromotedStoryViewModel.kt
@@ -39,9 +39,9 @@ class PromotedStoryViewModel(
     )
   }
 
-  /** Starts [ResumeLessonActivity] if a saved exploration is selected
-   *  or [ExplorationActivity] if an un-started recommended story is selected.
-   */
+  /**
+   * Starts [ResumeLessonActivity] if a saved exploration is selected or [ExplorationActivity] if an
+   * un-started recommended story is selected.   */
   fun clickOnPromotedStoryTile(@Suppress("UNUSED_PARAMETER") v: View) {
     promotedStoryClickListener.promotedStoryClicked(promotedStory)
   }

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingNavigationListener.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingNavigationListener.kt
@@ -1,6 +1,6 @@
 package org.oppia.android.app.onboarding
 
-/** Listener for buttons in OnboardingFragment */
+/** Listener for buttons in OnboardingFragment. */
 interface OnboardingNavigationListener {
 
   /** Skips onboarding slide. */

--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageActivity.kt
@@ -7,7 +7,6 @@ import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import org.oppia.android.app.drawer.NAVIGATION_PROFILE_ID_ARGUMENT_KEY
 import org.oppia.android.app.model.AppLanguageActivityParams
-import org.oppia.android.app.model.AppLanguageActivityResultBundle
 import org.oppia.android.app.model.AppLanguageActivityStateBundle
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.ScreenName.APP_LANGUAGE_ACTIVITY
@@ -67,16 +66,7 @@ class AppLanguageActivity : InjectableAutoLocalizedAppCompatActivity() {
     }
   }
 
-  override fun onBackPressed() {
-    val resultBundle = AppLanguageActivityResultBundle.newBuilder().apply {
-      oppiaLanguage = appLanguageActivityPresenter.getLanguageSelected()
-    }.build()
-    val intent = Intent().apply {
-      putProtoExtra(MESSAGE_APP_LANGUAGE_ARGUMENT_KEY, resultBundle)
-    }
-    setResult(REQUEST_CODE_APP_LANGUAGE, intent)
-    finish()
-  }
+  override fun onBackPressed() = finish()
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)

--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageActivityPresenter.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.options
 
-import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import org.oppia.android.R
@@ -12,7 +11,7 @@ import javax.inject.Inject
 /** The presenter for [AppLanguageActivity]. */
 @ActivityScope
 class AppLanguageActivityPresenter @Inject constructor(private val activity: AppCompatActivity) {
-  private lateinit var oppiaLangauge: OppiaLanguage
+  private lateinit var oppiaLanguage: OppiaLanguage
 
   /** Initializes and creates the views for [AppLanguageActivity]. */
   fun handleOnCreate(oppiaLanguage: OppiaLanguage, profileId: Int) {
@@ -20,13 +19,7 @@ class AppLanguageActivityPresenter @Inject constructor(private val activity: App
       activity,
       R.layout.app_language_activity,
     )
-    binding.appLanguageToolbar.setNavigationOnClickListener {
-      val intent = Intent().apply {
-        putExtra(MESSAGE_APP_LANGUAGE_ARGUMENT_KEY, oppiaLanguage)
-      }
-      (activity as AppLanguageActivity).setResult(REQUEST_CODE_APP_LANGUAGE, intent)
-      activity.finish()
-    }
+    binding.appLanguageToolbar.setNavigationOnClickListener { activity.finish() }
     setLanguageSelected(oppiaLanguage)
     if (getAppLanguageFragment() == null) {
       val appLanguageFragment = AppLanguageFragment.newInstance(oppiaLanguage, profileId)
@@ -37,13 +30,11 @@ class AppLanguageActivityPresenter @Inject constructor(private val activity: App
 
   /** Set the selected language for this Activity. */
   fun setLanguageSelected(oppiaLanguage: OppiaLanguage) {
-    this.oppiaLangauge = oppiaLanguage
+    this.oppiaLanguage = oppiaLanguage
   }
 
   /** Return's the selected language for this Activity. */
-  fun getLanguageSelected(): OppiaLanguage {
-    return oppiaLangauge
-  }
+  fun getLanguageSelected(): OppiaLanguage = oppiaLanguage
 
   private fun getAppLanguageFragment(): AppLanguageFragment? {
     return activity.supportFragmentManager

--- a/app/src/main/java/org/oppia/android/app/options/OptionControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionControlsViewModel.kt
@@ -25,6 +25,9 @@ import javax.inject.Inject
 /** [ViewModel] for [OptionsFragment]. */
 private const val OPTIONS_ITEM_VIEW_MODEL_LIST_PROVIDER_ID =
   "OPTIONS_ITEM_VIEW_MODEL_LIST_PROVIDER_ID"
+
+// TODO: Finish redoing viewmodel.
+
 /** Options settings view model for the recycler view in [OptionsFragment]. */
 @FragmentScope
 class OptionControlsViewModel @Inject constructor(
@@ -43,7 +46,8 @@ class OptionControlsViewModel @Inject constructor(
   private val loadAudioLanguageListListener = activity as LoadAudioLanguageListListener
   private val loadAppLanguageListListener = activity as LoadAppLanguageListListener
   private var isFirstOpen = true
-  /** Holds [Boolean] value showing if UI is initialized.  */
+
+  /** Holds [Boolean] value showing if UI is initialized. */
   val uiLiveData = MutableLiveData<Boolean>()
   /** Holds the index for the currently selected fragment. */
   val selectedFragmentIndex = ObservableField<Int>()

--- a/app/src/main/java/org/oppia/android/app/options/OptionControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionControlsViewModel.kt
@@ -43,7 +43,6 @@ class OptionControlsViewModel @Inject constructor(
   private val loadReadingTextSizeListener = activity as LoadReadingTextSizeListener
   private val loadAudioLanguageListListener = activity as LoadAudioLanguageListListener
   private val loadAppLanguageListListener = activity as LoadAppLanguageListListener
-  private var isFirstOpen = true
 
   private val optionsItemViewModelProvider by lazy { createOptionsItemViewModelProvider() }
 
@@ -109,15 +108,7 @@ class OptionControlsViewModel @Inject constructor(
   private fun createReadingTextSizeViewModel(profile: Profile): OptionsReadingTextSizeViewModel {
     return OptionsReadingTextSizeViewModel(
       routeToReadingTextSizeListener, loadReadingTextSizeListener, resourceHandler
-    ).apply {
-      readingTextSize.set(profile.readingTextSize)
-
-      // Loading the initial options in the sub-options container
-      if (isMultipane.get()!! && isFirstOpen) {
-        loadReadingTextSizeFragment()
-        isFirstOpen = false
-      }
-    }
+    ).also { it.readingTextSize.set(profile.readingTextSize) }
   }
 
   private fun createAppLanguageViewModel(language: OppiaLanguage): OptionsAppLanguageViewModel? {
@@ -137,13 +128,5 @@ class OptionControlsViewModel @Inject constructor(
       profile.audioLanguage,
       resourceHandler.computeLocalizedDisplayName(profile.audioLanguage)
     )
-  }
-
-  /**
-   * Sets [isFirstOpen] value which controls the loading of the initial extra-option fragment in the
-   * case of multipane.
-   */
-  fun isFirstOpen(isFirstOpen: Boolean) {
-    this.isFirstOpen = isFirstOpen
   }
 }

--- a/app/src/main/java/org/oppia/android/app/options/OptionsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsActivity.kt
@@ -8,7 +8,6 @@ import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import org.oppia.android.app.drawer.NAVIGATION_PROFILE_ID_ARGUMENT_KEY
-import org.oppia.android.app.model.AppLanguageActivityResultBundle
 import org.oppia.android.app.model.AudioLanguage
 import org.oppia.android.app.model.AudioLanguageActivityResultBundle
 import org.oppia.android.app.model.OppiaLanguage
@@ -111,13 +110,6 @@ class OptionsActivity :
         )
         optionActivityPresenter.updateReadingTextSize(textSizeResults.selectedReadingTextSize)
       }
-      REQUEST_CODE_APP_LANGUAGE -> {
-        val oppiaLanguage = data.getProtoExtra(
-          MESSAGE_APP_LANGUAGE_ARGUMENT_KEY,
-          AppLanguageActivityResultBundle.getDefaultInstance()
-        ).oppiaLanguage
-        optionActivityPresenter.updateAppLanguage(oppiaLanguage)
-      }
       REQUEST_CODE_AUDIO_LANGUAGE -> {
         val audioLanguage = data.getProtoExtra(
           MESSAGE_AUDIO_LANGUAGE_RESULTS_KEY, AudioLanguageActivityResultBundle.getDefaultInstance()
@@ -128,13 +120,12 @@ class OptionsActivity :
   }
 
   override fun routeAppLanguageList(oppiaLanguage: OppiaLanguage) {
-    startActivityForResult(
+    startActivity(
       AppLanguageActivity.createAppLanguageActivityIntent(
         this,
         oppiaLanguage,
         profileId!!
-      ),
-      REQUEST_CODE_APP_LANGUAGE
+      )
     )
   }
 

--- a/app/src/main/java/org/oppia/android/app/options/OptionsActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsActivityPresenter.kt
@@ -86,27 +86,25 @@ class OptionsActivityPresenter @Inject constructor(
       ) as OptionsFragment?
   }
 
-  /** Updates [ReadingTextSize] value in
-   * [OptionsFragment] when user selects new value. */
+  /** Updates [ReadingTextSize] value in [OptionsFragment] when user selects new value. */
   fun updateReadingTextSize(textSize: ReadingTextSize) {
     getOptionFragment()?.updateReadingTextSize(textSize)
   }
 
-  /** Updates [OppiaLanguage] value in
-   * [OptionsFragment] when user selects new value. */
+  /** Updates [OppiaLanguage] value in [OptionsFragment] when user selects new value. */
   fun updateAppLanguage(oppiaLanguage: OppiaLanguage) {
     getOptionFragment()?.updateAppLanguage(oppiaLanguage)
   }
 
-  /** Updates [AudioLanguage] value in
-   * [OptionsFragment] when user selects new value. */
+  /** Updates [AudioLanguage] value in [OptionsFragment] when user selects new value. */
   fun updateAudioLanguage(audioLanguage: AudioLanguage) {
     getOptionFragment()?.updateAudioLanguage(audioLanguage)
   }
 
-  /** Returns a new instance of [ReadingTextSizeFragment].
+  /**
+   * Returns a new instance of [ReadingTextSizeFragment].
    *
-   * @param [ReadingTextSize] the initially selected reading text size
+   * @param textSize the initially selected reading text size
    */
   fun loadReadingTextSizeFragment(textSize: ReadingTextSize) {
     val readingTextSizeFragment = ReadingTextSizeFragment.newInstance(textSize)
@@ -117,7 +115,8 @@ class OptionsActivityPresenter @Inject constructor(
     getOptionFragment()?.setSelectedFragment(READING_TEXT_SIZE_FRAGMENT)
   }
 
-  /** Returns a new instance of [AppLanguageFragment].
+  /**
+   * Returns a new instance of [AppLanguageFragment].
    *
    * @param appLanguage the initially selected App language
    */
@@ -131,7 +130,8 @@ class OptionsActivityPresenter @Inject constructor(
     getOptionFragment()?.setSelectedFragment(APP_LANGUAGE_FRAGMENT)
   }
 
-  /** Returns a new instance of [AudioLanguageFragment].
+  /**
+   * Returns a new instance of [AudioLanguageFragment].
    *
    * @param audioLanguage the initially selected audio language
    */

--- a/app/src/main/java/org/oppia/android/app/options/OptionsFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsFragment.kt
@@ -21,8 +21,6 @@ const val MESSAGE_APP_LANGUAGE_ARGUMENT_KEY = "OptionsFragment.message_app_langu
 const val MESSAGE_AUDIO_LANGUAGE_RESULTS_KEY = "OptionsFragment.message_audio_language"
 /** Request code for [ReadingTextSize]. */
 const val REQUEST_CODE_TEXT_SIZE = 1
-/** Request code for [OppiaLanguage]. */
-const val REQUEST_CODE_APP_LANGUAGE = 2
 /** Request code for [AudioLanguage]. */
 const val REQUEST_CODE_AUDIO_LANGUAGE = 3
 

--- a/app/src/main/java/org/oppia/android/app/options/OptionsFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsFragment.kt
@@ -19,11 +19,11 @@ const val MESSAGE_READING_TEXT_SIZE_RESULTS_KEY = "OptionsFragment.message_readi
 const val MESSAGE_APP_LANGUAGE_ARGUMENT_KEY = "OptionsFragment.message_app_language"
 /** OnActivity result key to access [AudioLanguage] result. */
 const val MESSAGE_AUDIO_LANGUAGE_RESULTS_KEY = "OptionsFragment.message_audio_language"
-/** Request code for [ReadingTextSize] */
+/** Request code for [ReadingTextSize]. */
 const val REQUEST_CODE_TEXT_SIZE = 1
-/** Request code for [OppiaLanguage] */
+/** Request code for [OppiaLanguage]. */
 const val REQUEST_CODE_APP_LANGUAGE = 2
-/** Request code for [AudioLanguage] */
+/** Request code for [AudioLanguage]. */
 const val REQUEST_CODE_AUDIO_LANGUAGE = 3
 
 private const val IS_MULTIPANE_EXTRA = "IS_MULTIPANE_EXTRA"
@@ -76,27 +76,21 @@ class OptionsFragment : InjectableFragment() {
     )
   }
 
-  /** Updates [ReadingTextSize] value in
-   * [OptionsFragment] when user selects new value.
-   */
+  /** Updates [ReadingTextSize] value in [OptionsFragment] when user selects new value. */
   fun updateReadingTextSize(textSize: ReadingTextSize) {
     optionsFragmentPresenter.runAfterUIInitialization {
       optionsFragmentPresenter.updateReadingTextSize(textSize)
     }
   }
 
-  /** Updates [OppiaLanguage] value in
-   * [OptionsFragment] when user selects new value.
-   */
+  /** Updates [OppiaLanguage] value in [OptionsFragment] when user selects new value. */
   fun updateAppLanguage(oppiaLanguage: OppiaLanguage) {
     optionsFragmentPresenter.runAfterUIInitialization {
       optionsFragmentPresenter.updateAppLanguage(oppiaLanguage)
     }
   }
 
-  /** Updates [AudioLanguage] value in
-   * [OptionsFragment] when user selects new value.
-   */
+  /** Updates [AudioLanguage] value in [OptionsFragment] when user selects new value. */
   fun updateAudioLanguage(audioLanguage: AudioLanguage) {
     optionsFragmentPresenter.runAfterUIInitialization {
       optionsFragmentPresenter.updateAudioLanguage(audioLanguage)

--- a/app/src/main/java/org/oppia/android/app/options/OptionsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsFragmentPresenter.kt
@@ -66,7 +66,6 @@ class OptionsFragmentPresenter @Inject constructor(
     selectedFragment: String
   ): View? {
     viewModel.isUIInitialized(false)
-    viewModel.isFirstOpen(isFirstOpen)
     viewModel.isMultipane.set(isMultipane)
     binding = OptionsFragmentBinding.inflate(
       inflater,
@@ -89,6 +88,19 @@ class OptionsFragmentPresenter @Inject constructor(
     }
     setSelectedFragment(selectedFragment)
     viewModel.isUIInitialized(true)
+
+    var hasDefaultInitializedFragment = false
+    viewModel.optionsListLiveData.observe(fragment) { viewModels ->
+      if (!hasDefaultInitializedFragment) {
+        viewModels.filterIsInstance<OptionsReadingTextSizeViewModel>().singleOrNull()?.let {
+          if (isMultipane && isFirstOpen) {
+            it.loadReadingTextSizeFragment()
+          }
+          hasDefaultInitializedFragment = true
+        }
+      }
+    }
+
     return binding.root
   }
 
@@ -112,26 +124,22 @@ class OptionsFragmentPresenter @Inject constructor(
         }
         else -> throw IllegalArgumentException("Encountered unexpected view model: $viewModel")
       }
-    }
-      .registerViewDataBinder(
-        viewType = ViewType.VIEW_TYPE_READING_TEXT_SIZE,
-        inflateDataBinding = OptionStoryTextSizeBinding::inflate,
-        setViewModel = this::bindReadingTextSize,
-        transformViewModel = { it as OptionsReadingTextSizeViewModel }
-      )
-      .registerViewDataBinder(
-        viewType = ViewType.VIEW_TYPE_APP_LANGUAGE,
-        inflateDataBinding = OptionAppLanguageBinding::inflate,
-        setViewModel = this::bindAppLanguage,
-        transformViewModel = { it as OptionsAppLanguageViewModel }
-      )
-      .registerViewDataBinder(
-        viewType = ViewType.VIEW_TYPE_AUDIO_LANGUAGE,
-        inflateDataBinding = OptionAudioLanguageBinding::inflate,
-        setViewModel = this::bindAudioLanguage,
-        transformViewModel = { it as OptionsAudioLanguageViewModel }
-      )
-      .build()
+    }.registerViewDataBinder(
+      viewType = ViewType.VIEW_TYPE_READING_TEXT_SIZE,
+      inflateDataBinding = OptionStoryTextSizeBinding::inflate,
+      setViewModel = this::bindReadingTextSize,
+      transformViewModel = { it as OptionsReadingTextSizeViewModel }
+    ).registerViewDataBinder(
+      viewType = ViewType.VIEW_TYPE_APP_LANGUAGE,
+      inflateDataBinding = OptionAppLanguageBinding::inflate,
+      setViewModel = this::bindAppLanguage,
+      transformViewModel = { it as OptionsAppLanguageViewModel }
+    ).registerViewDataBinder(
+      viewType = ViewType.VIEW_TYPE_AUDIO_LANGUAGE,
+      inflateDataBinding = OptionAudioLanguageBinding::inflate,
+      setViewModel = this::bindAudioLanguage,
+      transformViewModel = { it as OptionsAudioLanguageViewModel }
+    ).build()
   }
 
   private fun bindReadingTextSize(

--- a/app/src/main/java/org/oppia/android/app/options/OptionsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsFragmentPresenter.kt
@@ -29,7 +29,7 @@ import java.security.InvalidParameterException
 import javax.inject.Inject
 
 private const val READING_TEXT_SIZE_TAG = "ReadingTextSize"
-private const val APP_LANGUAGE_TAG = "AppLanguage"
+private const val APP_LANGUAGE_TAG = "OptionsFragmentPresenter"
 private const val AUDIO_LANGUAGE_TAG = "AudioLanguage"
 private const val READING_TEXT_SIZE_ERROR =
   "Something went wrong while updating the reading text size"
@@ -189,8 +189,9 @@ class OptionsFragmentPresenter @Inject constructor(
     VIEW_TYPE_AUDIO_LANGUAGE
   }
 
-  /** Updates [ReadingTextSize] value in [OptionsFragment] when user selects new value
-   * and notifies the adapter to refresh after the changes.
+  /**
+   * Updates [ReadingTextSize] value in [OptionsFragment] when user selects new value and notifies
+   * the adapter to refresh after the changes.
    *
    * @param textSize new textSize to be set as current
    */
@@ -211,38 +212,33 @@ class OptionsFragmentPresenter @Inject constructor(
     recyclerViewAdapter.notifyItemChanged(0)
   }
 
-  /** Updates [OppiaLanguage] value in [OptionsFragment] when user selects new value
-   * and notifies the adapter to refresh after the changes.
+  /**
+   * Updates [OppiaLanguage] value in [OptionsFragment] when user selects new value and notifies the
+   * adapter to refresh after the changes.
    *
    * @param oppiaLanguage new oppiaLanguage to be set as current
    */
   fun updateAppLanguage(oppiaLanguage: OppiaLanguage) {
-    val appLanguageSelection = AppLanguageSelection.newBuilder().apply {
+    val selection = AppLanguageSelection.newBuilder().apply {
       selectedLanguage = oppiaLanguage
       selectedLanguageValue = oppiaLanguage.number
     }.build()
 
-    translationController.updateAppLanguage(
-      profileId, appLanguageSelection
-    ).toLiveData().observe(
-      fragment,
-      {
-        when (it) {
-          is AsyncResult.Success -> {
-            appLanguage = oppiaLanguage
-          }
-          is AsyncResult.Failure ->
-            oppiaLogger.e(APP_LANGUAGE_TAG, "$APP_LANGUAGE_ERROR", it.error)
-          is AsyncResult.Pending -> {} // Wait for a result.
-        }
+    translationController.updateAppLanguage(profileId, selection).toLiveData().observe(fragment) {
+      when (it) {
+        is AsyncResult.Success -> appLanguage = oppiaLanguage
+        is AsyncResult.Failure ->
+          oppiaLogger.e(APP_LANGUAGE_TAG, "$APP_LANGUAGE_ERROR: $oppiaLanguage.", it.error)
+        is AsyncResult.Pending -> {} // Wait for a result.
       }
-    )
+    }
 
     recyclerViewAdapter.notifyItemChanged(1)
   }
 
-  /** Updates [AudioLanguage] value in [OptionsFragment] when user selects new value
-   * and notifies the adapter to refresh after the changes.
+  /**
+   * Updates [AudioLanguage] value in [OptionsFragment] when user selects new value and notifies the
+   * adapter to refresh after the changes.
    *
    * @param audioLanguage new audioLanguage to be set as current
    */
@@ -264,6 +260,7 @@ class OptionsFragmentPresenter @Inject constructor(
   /**
    * Used to fix the race condition that happens when the presenter tries to call a function before
    * [handleCreateView] is completely executed.
+   *
    * @param action what to execute after the UI is initialized.
    */
   fun runAfterUIInitialization(action: () -> Unit) {

--- a/app/src/main/java/org/oppia/android/app/options/OptionsItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsItemViewModel.kt
@@ -3,7 +3,7 @@ package org.oppia.android.app.options
 import androidx.databinding.ObservableField
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** Option items view model for the recyclerView in [OptionsFragment] */
+/** Option items view model for the recyclerView in [OptionsFragment]. */
 abstract class OptionsItemViewModel : ObservableViewModel() {
   val isMultipane = ObservableField<Boolean>(false)
   val itemIndex = ObservableField<Int>()

--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioFragment.kt
@@ -99,9 +99,9 @@ class AudioFragment :
   override fun disableAudioWhileOnCellular(saveUserChoice: Boolean) =
     audioFragmentPresenter.handleDisableAudio(saveUserChoice)
 
-  /** Used in data binding to know if user is touching SeekBar */
+  /** Used in data binding to know if user is touching SeekBar. */
   override fun getUserIsSeeking() = audioFragmentPresenter.userIsSeeking
 
-  /** Used in data binding to know position of user's touch */
+  /** Used in data binding to know position of user's touch. */
   override fun getUserPosition() = audioFragmentPresenter.userProgress
 }

--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
@@ -70,7 +70,7 @@ class AudioFragmentPresenter @Inject constructor(
   private var isPauseAudioRequestPending = false
   private lateinit var binding: AudioFragmentBinding
 
-  /** Sets up SeekBar listener, ViewModel, and gets VoiceoverMappings or restores saved state */
+  /** Sets up SeekBar listener, ViewModel, and gets VoiceoverMappings or restores saved state. */
   fun handleCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -192,14 +192,14 @@ class AudioFragmentPresenter @Inject constructor(
     return getAudioLanguage(profile.audioLanguage)
   }
 
-  /** Sets selected language code in presenter and ViewModel */
+  /** Sets selected language code in presenter and ViewModel. */
   fun languageSelected(language: String) {
     if (viewModel.selectedLanguageCode != language) {
       viewModel.setAudioLanguageCode(language)
     }
   }
 
-  /** Shows language dialog fragment with language list from exploration */
+  /** Shows language dialog fragment with language list from exploration. */
   fun showLanguageDialogFragment() {
     val previousFragment = fragment.childFragmentManager.findFragmentByTag(TAG_LANGUAGE_DIALOG)
     if (previousFragment != null) {
@@ -212,14 +212,14 @@ class AudioFragmentPresenter @Inject constructor(
     dialogFragment.showNow(fragment.childFragmentManager, TAG_LANGUAGE_DIALOG)
   }
 
-  /** Pauses audio if in prepared state */
+  /** Pauses audio if in prepared state. */
   fun handleOnStop() {
     if (!activity.isChangingConfigurations && prepared) {
       viewModel.pauseAudio()
     }
   }
 
-  /** Releases audio player resources */
+  /** Releases audio player resources. */
   fun handleOnDestroy() {
     if (!activity.isChangingConfigurations) {
       viewModel.handleRelease()

--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioViewModel.kt
@@ -44,7 +44,7 @@ class AudioViewModel @Inject constructor(
   var selectedLanguageUnavailable = ObservableBoolean()
   var selectedLanguageName = ObservableField<String>("")
 
-  /** Mirrors PlayStatus in AudioPlayerController except adds LOADING state */
+  /** Mirrors PlayStatus in AudioPlayerController except adds LOADING state. */
   enum class UiAudioPlayStatus {
     FAILED,
     LOADING,
@@ -123,7 +123,7 @@ class AudioViewModel @Inject constructor(
     }
   }
 
-  /** Sets language code for data binding and changes data source to correct audio */
+  /** Sets language code for data binding and changes data source to correct audio. */
   fun setAudioLanguageCode(languageCode: String) {
     selectedLanguageCode = languageCode
     currentLanguageCode.set(languageCode)
@@ -132,7 +132,7 @@ class AudioViewModel @Inject constructor(
     )
   }
 
-  /** Plays or pauses AudioController depending on passed in state */
+  /** Plays or pauses AudioController depending on passed in state. */
   fun togglePlayPause(type: UiAudioPlayStatus?) {
     if (type == UiAudioPlayStatus.PLAYING) {
       audioPlayerController.pause(isFromExplicitUserAction = true)

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -192,7 +192,7 @@ class ExplorationActivityPresenter @Inject constructor(
     }
   }
 
-  /** Action for onOptionsItemSelected */
+  /** Action for onOptionsItemSelected. */
   fun handleOnOptionsItemSelected(itemId: Int): Boolean {
     return when (itemId) {
       R.id.action_options -> {

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationViewModel.kt
@@ -5,7 +5,7 @@ import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import javax.inject.Inject
 
-/** The ViewModel for [ExplorationActivity] */
+/** The ViewModel for [ExplorationActivity]. */
 @ActivityScope
 class ExplorationViewModel @Inject constructor() : ObservableViewModel() {
   /** Used to control visibility of audio button. */

--- a/app/src/main/java/org/oppia/android/app/player/state/answerhandling/InteractionAnswerHandler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/answerhandling/InteractionAnswerHandler.kt
@@ -36,10 +36,10 @@ interface InteractionAnswerReceiver {
   fun onAnswerReadyForSubmission(answer: UserAnswer)
 }
 
-/** Categories of errors that can be inferred from a pending answer.  */
+/** Categories of errors that can be inferred from a pending answer. */
 enum class AnswerErrorCategory {
-  /** Corresponds to errors that may be found while the user is trying to input an answer.  */
+  /** Corresponds to errors that may be found while the user is trying to input an answer. */
   REAL_TIME,
-  /** Corresponds to errors that may be found only when a user tries to submit an answer.  */
+  /** Corresponds to errors that may be found only when a user tries to submit an answer. */
   SUBMIT_TIME
 }

--- a/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivity.kt
@@ -32,7 +32,7 @@ internal const val TEST_ACTIVITY_EXPLORATION_ID_EXTRA_KEY =
 internal const val TEST_ACTIVITY_SHOULD_SAVE_PARTIAL_PROGRESS_EXTRA_KEY =
   "StateFragmentTestActivity.test_activity_should_save_partial_progress"
 
-/** Test Activity used for testing StateFragment */
+/** Test Activity used for testing StateFragment. */
 class StateFragmentTestActivity :
   InjectableAutoLocalizedAppCompatActivity(),
   StopStatePlayingSessionWithSavedProgressListener,

--- a/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 private const val TEST_ACTIVITY_TAG = "TestActivity"
 
-/** The presenter for [StateFragmentTestActivity] */
+/** The presenter for [StateFragmentTestActivity]. */
 @ActivityScope
 class StateFragmentTestActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity,

--- a/app/src/main/java/org/oppia/android/app/profileprogress/ProfileProgressItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/profileprogress/ProfileProgressItemViewModel.kt
@@ -2,5 +2,7 @@ package org.oppia.android.app.profileprogress
 
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** Super-class for generalising different views for the recyclerView in [ProfileProgressFragment] */
+/**
+ * Super-class for generalising different views for the recyclerView in [ProfileProgressFragment].
+ */
 abstract class ProfileProgressItemViewModel : ObservableViewModel()

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivityPresenter.kt
@@ -16,7 +16,7 @@ class ResumeLessonActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity
 ) {
 
-  /** Handles onCreate() method of the [ResumeLessonActivity] */
+  /** Handles onCreate() method of the [ResumeLessonActivity]. */
   fun handleOnCreate(
     profileId: ProfileId,
     topicId: String,

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileResetPinActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileResetPinActivity.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 const val PROFILE_RESET_PIN_PROFILE_ID_EXTRA_KEY =
   "ProfileResetPinActivity.profile_reset_pin_profile_id"
 
-/**Argument key for confirming profile is admin. */
+/** Argument key for confirming profile is admin. */
 const val PROFILE_RESET_PIN_IS_ADMIN_EXTRA_KEY =
   "ProfileResetPinActivity.profile_reset_pin_is_admin"
 

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileResetPinViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileResetPinViewModel.kt
@@ -20,11 +20,12 @@ class ProfileResetPinViewModel @Inject constructor() : ObservableViewModel() {
   /** The new pin inputted by the user. */
   val inputPin = ObservableField("")
 
-  /** The second PIN inputted by the user
-   *  (is expected to be the same as [inputPin] to confirm the user knows this new number).
+  /**
+   * The second PIN inputted by the user (is expected to be the same as [inputPin] to confirm the
+   * user knows this new number).
    */
   val inputConfirmPin = ObservableField("")
 
-  /** Whether the save pin button is enabled (i.e. there is no issue with the inputted PINs.) */
+  /** Whether the save pin button is enabled (i.e. there is no issue with the inputted PINs.). */
   val isButtonActive = ObservableField(false)
 }

--- a/app/src/main/java/org/oppia/android/app/story/storyitemviewmodel/StoryItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/story/storyitemviewmodel/StoryItemViewModel.kt
@@ -2,5 +2,5 @@ package org.oppia.android.app.story.storyitemviewmodel
 
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** Super-class for generalising different views for the recyclerView in [StoryFragment] */
+/** Super-class for generalising different views for the recyclerView in [StoryFragment]. */
 abstract class StoryItemViewModel : ObservableViewModel()

--- a/app/src/main/java/org/oppia/android/app/testing/AudioFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/AudioFragmentTestActivity.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 const val AUDIO_FRAGMENT_TEST_PROFILE_ID_ARGUMENT_KEY =
   "AudioFragmentTestActivity.audio_fragment_test_profile_id"
 
-/** Test Activity used for testing AudioFragment */
+/** Test Activity used for testing AudioFragment. */
 class AudioFragmentTestActivity : InjectableAutoLocalizedAppCompatActivity() {
 
   @Inject

--- a/app/src/main/java/org/oppia/android/app/testing/AudioFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/AudioFragmentTestActivityPresenter.kt
@@ -10,7 +10,7 @@ import org.oppia.android.app.model.VoiceoverMapping
 import org.oppia.android.app.player.audio.AudioFragment
 import javax.inject.Inject
 
-/** The presenter for [AudioFragmentTestActivity] */
+/** The presenter for [AudioFragmentTestActivity]. */
 @ActivityScope
 class AudioFragmentTestActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity

--- a/app/src/main/java/org/oppia/android/app/testing/ConceptCardFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ConceptCardFragmentTestActivity.kt
@@ -12,7 +12,7 @@ import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProtoExtra
 import javax.inject.Inject
 
-/** Test Activity used for testing ConceptCardFragment */
+/** Test Activity used for testing ConceptCardFragment. */
 class ConceptCardFragmentTestActivity :
   InjectableAutoLocalizedAppCompatActivity(),
   ConceptCardListener {

--- a/app/src/main/java/org/oppia/android/app/testing/ConceptCardFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ConceptCardFragmentTestActivityPresenter.kt
@@ -9,7 +9,7 @@ import org.oppia.android.domain.topic.TEST_SKILL_ID_0
 import org.oppia.android.domain.topic.TEST_SKILL_ID_1
 import javax.inject.Inject
 
-/** The presenter for [ConceptCardFragmentTestActivity] */
+/** The presenter for [ConceptCardFragmentTestActivity]. */
 class ConceptCardFragmentTestActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity
 ) {

--- a/app/src/main/java/org/oppia/android/app/testing/DragDropTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/DragDropTestActivity.kt
@@ -5,7 +5,7 @@ import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import javax.inject.Inject
 
-/** Test Activity used for testing [DragAndDropItemFacilitator] functionality */
+/** Test Activity used for testing [DragAndDropItemFacilitator] functionality. */
 class DragDropTestActivity : InjectableAutoLocalizedAppCompatActivity() {
 
   @Inject

--- a/app/src/main/java/org/oppia/android/app/testing/DragDropTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/DragDropTestActivityPresenter.kt
@@ -4,7 +4,7 @@ import androidx.appcompat.app.AppCompatActivity
 import org.oppia.android.R
 import javax.inject.Inject
 
-/** The presenter for [DragDropTestActivity] */
+/** The presenter for [DragDropTestActivity]. */
 class DragDropTestActivityPresenter @Inject constructor(private val activity: AppCompatActivity) {
 
   fun handleOnCreate() {

--- a/app/src/main/java/org/oppia/android/app/testing/ImageRegionSelectionTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ImageRegionSelectionTestActivity.kt
@@ -7,7 +7,7 @@ import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import org.oppia.android.app.utility.ClickableAreasImage
 import org.oppia.android.app.utility.OnClickableAreaClickedListener
 
-/** Test Activity used for testing [ClickableAreasImage] functionality */
+/** Test Activity used for testing [ClickableAreasImage] functionality. */
 class ImageRegionSelectionTestActivity : InjectableAutoLocalizedAppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/oppia/android/app/testing/ImageRegionSelectionTestFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ImageRegionSelectionTestFragment.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 const val IMAGE_REGION_SELECTION_TEST_FRAGMENT_TAG = "image_region_selection_test_fragment"
 
 // TODO(#59): Make this fragment only included in relevant tests instead of all prod builds.
-/** Test Fragment used for testing [ClickableAreasImage] functionality */
+/** Test Fragment used for testing [ClickableAreasImage] functionality. */
 class ImageRegionSelectionTestFragment : InjectableFragment(), OnClickableAreaClickedListener {
   @Inject
   lateinit var imageRegionSelectionTestFragmentPresenter:

--- a/app/src/main/java/org/oppia/android/app/testing/ImageRegionSelectionTestFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ImageRegionSelectionTestFragmentPresenter.kt
@@ -12,7 +12,7 @@ import org.oppia.android.app.utility.OnClickableAreaClickedListener
 import org.oppia.android.databinding.ImageRegionSelectionTestFragmentBinding
 import javax.inject.Inject
 
-/** The presenter for [ImageRegionSelectionTestActivity] */
+/** The presenter for [ImageRegionSelectionTestActivity]. */
 class ImageRegionSelectionTestFragmentPresenter @Inject constructor(
   private val fragment: Fragment
 ) {

--- a/app/src/main/java/org/oppia/android/app/testing/PoliciesFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/PoliciesFragmentTestActivity.kt
@@ -12,7 +12,7 @@ import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProtoExtra
 import javax.inject.Inject
 
-/** Test Activity used for testing [PoliciesFragment] */
+/** Test Activity used for testing [PoliciesFragment]. */
 class PoliciesFragmentTestActivity : TestActivity(), RouteToPoliciesListener {
 
   @Inject

--- a/app/src/main/java/org/oppia/android/app/testing/PoliciesFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/PoliciesFragmentTestActivityPresenter.kt
@@ -8,7 +8,7 @@ import org.oppia.android.app.model.PoliciesFragmentArguments
 import org.oppia.android.app.policies.PoliciesFragment
 import javax.inject.Inject
 
-/** The presenter for [PoliciesFragmentTestActivity] */
+/** The presenter for [PoliciesFragmentTestActivity]. */
 @ActivityScope
 class PoliciesFragmentTestActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity

--- a/app/src/main/java/org/oppia/android/app/testing/ProfileChooserFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ProfileChooserFragmentTestActivity.kt
@@ -5,7 +5,7 @@ import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import javax.inject.Inject
 
-/** Test Activity used for testing [ProfileChooserFragment] */
+/** Test Activity used for testing [ProfileChooserFragment]. */
 class ProfileChooserFragmentTestActivity : InjectableAutoLocalizedAppCompatActivity() {
 
   @Inject

--- a/app/src/main/java/org/oppia/android/app/testing/SpotlightFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/SpotlightFragmentTestActivityPresenter.kt
@@ -10,7 +10,7 @@ import org.oppia.android.app.topic.PROFILE_ID_ARGUMENT_KEY
 import org.oppia.android.databinding.SpotlightFragmentTestActivityBinding
 import javax.inject.Inject
 
-/** The presenter for [SpotlightFragmentTestActivity] */
+/** The presenter for [SpotlightFragmentTestActivity]. */
 @ActivityScope
 class SpotlightFragmentTestActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity

--- a/app/src/main/java/org/oppia/android/app/testing/TestFontScaleConfigurationUtilActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TestFontScaleConfigurationUtilActivityPresenter.kt
@@ -7,7 +7,7 @@ import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.utility.FontScaleConfigurationUtil
 import javax.inject.Inject
 
-/** The presenter for [TestFontScaleConfigurationUtilActivity] */
+/** The presenter for [TestFontScaleConfigurationUtilActivity]. */
 @ActivityScope
 class TestFontScaleConfigurationUtilActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity,

--- a/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivity.kt
@@ -8,7 +8,7 @@ import org.oppia.android.app.topic.revision.TopicRevisionFragment
 import org.oppia.android.app.topic.revisioncard.RevisionCardActivity
 import javax.inject.Inject
 
-/** Test Activity used for testing [TopicRevisionFragment] */
+/** Test Activity used for testing [TopicRevisionFragment]. */
 class TopicRevisionTestActivity :
   InjectableAutoLocalizedAppCompatActivity(),
   RouteToRevisionCardListener {

--- a/app/src/main/java/org/oppia/android/app/testing/activity/TestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/activity/TestActivity.kt
@@ -25,11 +25,8 @@ import javax.inject.Inject
  *   in tests
  */
 open class TestActivity : InjectableAutoLocalizedAppCompatActivity() {
-  @Inject
-  lateinit var appLanguageResourceHandler: AppLanguageResourceHandler
-
-  @Inject
-  lateinit var dateTimeUtil: DateTimeUtil
+  @Inject lateinit var appLanguageResourceHandler: AppLanguageResourceHandler
+  @Inject lateinit var dateTimeUtil: DateTimeUtil
 
   @Inject
   lateinit var topicActivityIntentFactory: ActivityIntentFactories.TopicActivityIntentFactory
@@ -38,17 +35,10 @@ open class TestActivity : InjectableAutoLocalizedAppCompatActivity() {
   lateinit var recentlyPlayedActivityIntentFactory:
     ActivityIntentFactories.RecentlyPlayedActivityIntentFactory
 
-  @Inject
-  lateinit var appLanguageWatcherMixin: AppLanguageWatcherMixin
-
-  @Inject
-  lateinit var mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil
-
-  @Inject
-  lateinit var activityRouter: ActivityRouter
-
-  @Inject
-  lateinit var activityLanguageLocaleHandler: ActivityLanguageLocaleHandler
+  @Inject lateinit var appLanguageWatcherMixin: AppLanguageWatcherMixin
+  @Inject lateinit var mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil
+  @Inject lateinit var activityRouter: ActivityRouter
+  @Inject lateinit var activityLanguageLocaleHandler: ActivityLanguageLocaleHandler
 
   override fun attachBaseContext(newBase: Context?) {
     super.attachBaseContext(newBase)
@@ -60,6 +50,12 @@ open class TestActivity : InjectableAutoLocalizedAppCompatActivity() {
     setContentView(R.layout.test_activity)
   }
 
+  override fun initializeMixin(appLanguageWatcherMixin: AppLanguageWatcherMixin) {
+    if (!forceDisableLanguageWatcherMixinInitialization) {
+      super.initializeMixin(appLanguageWatcherMixin)
+    }
+  }
+
   /** Activity injector for [TestActivity]. */
   interface Injector {
     /** Injects the prerequisite dependencies into [TestActivity]. */
@@ -67,6 +63,15 @@ open class TestActivity : InjectableAutoLocalizedAppCompatActivity() {
   }
 
   companion object {
+    /**
+     * A singleton control variable for tests to disable [AppLanguageWatcherMixin] initialization
+     * for all future [TestActivity]s until set back to false. This is useful for cases when tests
+     * want to manage mixin initialization directly.
+     *
+     * This value is false by default.
+     */
+    var forceDisableLanguageWatcherMixinInitialization = false
+
     /** Returns a new [Intent] for the given [Context] to launch new [TestActivity]s. */
     fun createIntent(context: Context): Intent = Intent(context, TestActivity::class.java)
   }

--- a/app/src/main/java/org/oppia/android/app/topic/TopicTab.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicTab.kt
@@ -56,7 +56,7 @@ enum class TopicTab(
       ) { "No tab corresponding to position: $position" }
     }
 
-    /** Returns the number of active tabs considering [enableExtraTopicTabsUi] */
+    /** Returns the number of active tabs considering [enableExtraTopicTabsUi]. */
     fun getTabCount(enableExtraTopicTabsUi: Boolean) =
       if (enableExtraTopicTabsUi) values().size else values().size - 2
   }

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -18,7 +18,7 @@ import org.oppia.android.util.parser.html.ConceptCardHtmlParserEntityType
 import org.oppia.android.util.parser.html.HtmlParser
 import javax.inject.Inject
 
-/** Presenter for [ConceptCardFragment], sets up bindings from ViewModel */
+/** Presenter for [ConceptCardFragment], sets up bindings from ViewModel. */
 @FragmentScope
 class ConceptCardFragmentPresenter @Inject constructor(
   private val fragment: Fragment,

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardListener.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardListener.kt
@@ -1,6 +1,6 @@
 package org.oppia.android.app.topic.conceptcard
 
-/** Allows parent activity to dismiss the [ConceptCardFragment] */
+/** Allows parent activity to dismiss the [ConceptCardFragment]. */
 interface ConceptCardListener {
   /** Called when the concept card dialog should be dismissed. */
   fun dismissConceptCard()

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardViewModel.kt
@@ -12,7 +12,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
-/** [ObservableViewModel] for concept card, providing rich text and worked examples */
+/** [ObservableViewModel] for concept card, providing rich text and worked examples. */
 @FragmentScope
 class ConceptCardViewModel @Inject constructor(
   private val topicController: TopicController,

--- a/app/src/main/java/org/oppia/android/app/topic/practice/practiceitemviewmodel/TopicPracticeItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/practice/practiceitemviewmodel/TopicPracticeItemViewModel.kt
@@ -2,5 +2,5 @@ package org.oppia.android.app.topic.practice.practiceitemviewmodel
 
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** Super-class for generalising different views for the recyclerView in [TopicPracticeFragment] */
+/** Super-class for generalising different views for the recyclerView in [TopicPracticeFragment]. */
 abstract class TopicPracticeItemViewModel : ObservableViewModel()

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityPresenter.kt
@@ -84,7 +84,7 @@ class RevisionCardActivityPresenter @Inject constructor(
     }
   }
 
-  /** Action for onOptionsItemSelected */
+  /** Action for onOptionsItemSelected. */
   fun handleOnOptionsItemSelected(itemId: Int): Boolean {
     return when (itemId) {
       R.id.action_options -> {

--- a/app/src/main/java/org/oppia/android/app/walkthrough/topiclist/WalkthroughTopicItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/walkthrough/topiclist/WalkthroughTopicItemViewModel.kt
@@ -2,5 +2,8 @@ package org.oppia.android.app.walkthrough.topiclist
 
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** Super-class for generalising different views for the recyclerView in [WalkthroughTopicListFragment] */
+/**
+ * Super-class for generalising different views for the recyclerView in
+ * [WalkthroughTopicListFragment].
+ */
 abstract class WalkthroughTopicItemViewModel : ObservableViewModel()

--- a/app/src/main/res/values/untranslated_strings.xml
+++ b/app/src/main/res/values/untranslated_strings.xml
@@ -97,7 +97,7 @@
   <string name="temporary_translate_to_english" translatable="false">Switch lesson to English</string>
   <!-- General test activity strings. -->
   <string name="test_activity_label" translatable="false">Test-only activity</string>
-  <!--These are names of languages localized to that particular language. -->
+  <!-- Human-readable names of languages localized to that particular language. -->
   <string name="hinglish_localized_language_name" translatable="false">हिन्दी</string>
   <string name="arabic_localized_language_name" translatable="false">العربية</string>
   <string name="english_localized_language_name" translatable="false">English</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt
@@ -208,7 +208,7 @@ class ProfileAndDeviceIdFragmentTest {
   fun testFragment_hasDeviceId() {
     initializeActivityAndAddFragment()
 
-    onDeviceIdLabelAt(position = 0).check(matches(withText(containsString("c85606ca6390"))))
+    onDeviceIdLabelAt(position = 0).check(matches(withText(containsString("0347439ebe8b"))))
   }
 
   @Test
@@ -228,7 +228,7 @@ class ProfileAndDeviceIdFragmentTest {
     val clipData = getCurrentClipData()
     assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
     assertThat(clipData?.itemCount).isEqualTo(1)
-    assertThat(clipData?.getItemAt(0)?.text).isEqualTo("c85606ca6390")
+    assertThat(clipData?.getItemAt(0)?.text).isEqualTo("0347439ebe8b")
   }
 
   @Test
@@ -309,7 +309,7 @@ class ProfileAndDeviceIdFragmentTest {
 
     // The second profile has a different learner ID.
     onLearnerIdAt(position = 1).check(matches(withText("a9fe66ab")))
-    onLearnerIdAt(position = 2).check(matches(withText("c368b501")))
+    onLearnerIdAt(position = 2).check(matches(withText("6e563e2f")))
   }
 
   @Test
@@ -324,7 +324,7 @@ class ProfileAndDeviceIdFragmentTest {
     val clipData = getCurrentClipData()
     assertThat(clipData?.description?.label).isEqualTo("A's learner ID")
     assertThat(clipData?.itemCount).isEqualTo(1)
-    assertThat(clipData?.getItemAt(0)?.text).isEqualTo("c368b501")
+    assertThat(clipData?.getItemAt(0)?.text).isEqualTo("6e563e2f")
   }
 
   @Test
@@ -772,16 +772,16 @@ class ProfileAndDeviceIdFragmentTest {
 
     val expectedShareText =
       """
-      Oppia app installation ID: 1216f42c89ec
+      Oppia app installation ID: 932459768f39
       - Profile name: Admin, learner ID: a9fe66ab
         - Uploading learner events: 3
         - Uploaded learner events: 2
         - Uploading uncategorized events: 1
         - Uploaded uncategorized events: 4
-      - Profile name: A, learner ID: c368b501
+      - Profile name: A, learner ID: 6e563e2f
         - Uploading learner events: 2
         - Uploaded learner events: 1
-      - Profile name: B, learner ID: 74facac7
+      - Profile name: B, learner ID: 5c0710a2
         - Uploading learner events: 1
         - Uploaded learner events: 2
       Current sync status: Waiting to schedule data uploading worker….

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/ViewEventLogsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/ViewEventLogsFragmentTest.kt
@@ -479,7 +479,9 @@ class ViewEventLogsFragmentTest {
     }
   }
 
-  /** Logs multiple event logs so that the recyclerview in [ViewEventLogsFragment] gets populated */
+  /**
+   * Logs multiple event logs so that the recyclerview in [ViewEventLogsFragment] gets populated.
+   */
   private fun logMultipleEvents() {
     fakeOppiaClock.setCurrentTimeMs(TEST_TIMESTAMP)
     analyticsController.logImportantEvent(

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -4826,7 +4826,7 @@ class StateFragmentTest {
     }
   }
 
-  /*** Returns a matcher that matches view based on non-zero width and height.*/
+  /** Returns a matcher that matches view based on non-zero width and height. */
   private class WithNonZeroDimensionsMatcher : TypeSafeMatcher<View>() {
 
     override fun matchesSafely(target: View): Boolean {

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -167,7 +167,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_initializeProfiles_checkProfilesAreShown() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
       scrollToPosition(position = 0)
@@ -205,13 +205,10 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_afterVisitingHomeActivity_showsJustNowText() {
-    val data = profileTestHelper.initializeProfiles()
+    // Note that the auto-log in here is simulating HomeActivity having been visited before (i.e.
+    // that a profile was previously logged in).
+    profileTestHelper.initializeProfiles(autoLogIn = true)
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
-      // Note that this wait is needed to simulate HomeActivity being
-      // visited by ensuring a profile was previously logged in.
-      it.onActivity {
-        profileTestHelper.waitForOperationToComplete(data)
-      }
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
@@ -230,13 +227,10 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_afterVisitingHomeActivity_changeConfiguration_showsJustNowText() {
-    val data = profileTestHelper.initializeProfiles()
+    // Note that the auto-log in here is simulating HomeActivity having been visited before (i.e.
+    // that a profile was previously logged in).
+    profileTestHelper.initializeProfiles(autoLogIn = true)
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
-      // Note that this wait is needed to simulate HomeActivity being
-      // visited by ensuring a profile was previously logged in.
-      it.onActivity {
-        profileTestHelper.waitForOperationToComplete(data)
-      }
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       onView(
@@ -256,7 +250,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_addManyProfiles_checkProfilesSortedAndNoAddProfile() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     profileTestHelper.addMoreProfiles(8)
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
@@ -325,7 +319,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_clickProfile_checkOpensPinPasswordActivity() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
       onView(
@@ -426,7 +420,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_multipleProfiles_checkText_addProfileIsVisible() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
       verifyTextOnProfileListItemAtPosition(
@@ -439,7 +433,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_multipleProfiles_checkDescriptionText_isDisplayed() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
       onView(
@@ -454,7 +448,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_clickAdminControls_opensAdminAuthActivity() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.administrator_controls_linear_layout)).perform(click())
@@ -465,7 +459,7 @@ class ProfileChooserFragmentTest {
 
   @Test
   fun testProfileChooserFragment_clickAddProfile_opensAdminAuthActivity() {
-    profileTestHelper.initializeProfiles()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
       onView(

--- a/app/src/sharedTest/java/org/oppia/android/app/utility/DragViewAction.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/utility/DragViewAction.kt
@@ -108,7 +108,7 @@ class DragViewAction(
   }
 }
 
-/** Class to find coordinates of an item within your RecyclerView.*/
+/** Class to find coordinates of an item within your RecyclerView. */
 class RecyclerViewCoordinatesProvider(
   private val position: Int,
   private val childItemCoordinatesProvider: CoordinatesProvider
@@ -120,7 +120,7 @@ class RecyclerViewCoordinatesProvider(
   }
 }
 
-/** Class to find coordinates of a child with a given id.*/
+/** Class to find coordinates of a child with a given id. */
 class ChildViewCoordinatesProvider(
   private val childViewId: Int,
   private val insideChildViewCoordinatesProvider: CoordinatesProvider
@@ -134,7 +134,7 @@ class ChildViewCoordinatesProvider(
   }
 }
 
-/**Class to provide coordinates above and under a View.*/
+/** Class to provide coordinates above and under a View. */
 enum class CustomGeneralLocation : CoordinatesProvider {
   UNDER_RIGHT {
     override fun calculateCoordinates(view: View): FloatArray {

--- a/app/src/test/java/org/oppia/android/app/testing/options/OptionsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/android/app/testing/options/OptionsFragmentTest.kt
@@ -133,7 +133,7 @@ class OptionsFragmentTest {
       it.onActivity { activity ->
         val loadedFragment =
           activity.supportFragmentManager.findFragmentById(R.id.multipane_options_container)
-        assertThat(loadedFragment is ReadingTextSizeFragment).isTrue()
+        assertThat(loadedFragment).isInstanceOf(ReadingTextSizeFragment::class.java)
       }
     }
   }
@@ -154,7 +154,7 @@ class OptionsFragmentTest {
       it.onActivity { activity ->
         val loadedFragment =
           activity.supportFragmentManager.findFragmentById(R.id.multipane_options_container)
-        assertThat(loadedFragment is ReadingTextSizeFragment).isTrue()
+        assertThat(loadedFragment).isInstanceOf(ReadingTextSizeFragment::class.java)
       }
     }
   }
@@ -194,7 +194,7 @@ class OptionsFragmentTest {
       it.onActivity { activity ->
         val loadedFragment =
           activity.supportFragmentManager.findFragmentById(R.id.multipane_options_container)
-        assertThat(loadedFragment is AppLanguageFragment).isTrue()
+        assertThat(loadedFragment).isInstanceOf(AppLanguageFragment::class.java)
       }
     }
   }
@@ -215,7 +215,7 @@ class OptionsFragmentTest {
       it.onActivity { activity ->
         val loadedFragment =
           activity.supportFragmentManager.findFragmentById(R.id.multipane_options_container)
-        assertThat(loadedFragment is AudioLanguageFragment).isTrue()
+        assertThat(loadedFragment).isInstanceOf(AudioLanguageFragment::class.java)
       }
     }
   }

--- a/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
@@ -125,17 +125,10 @@ class ActivityLanguageLocaleHandlerTest {
       TestActivity.createIntent(ApplicationProvider.getApplicationContext())
     )
 
-  @Inject
-  lateinit var context: Context
-
-  @Inject
-  lateinit var appLanguageLocaleHandler: AppLanguageLocaleHandler
-
-  @Inject
-  lateinit var translationController: TranslationController
-
-  @Inject
-  lateinit var monitorFactory: DataProviderTestMonitor.Factory
+  @Inject lateinit var context: Context
+  @Inject lateinit var appLanguageLocaleHandler: AppLanguageLocaleHandler
+  @Inject lateinit var translationController: TranslationController
+  @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
   @Before
   fun setUp() {
@@ -164,10 +157,29 @@ class ActivityLanguageLocaleHandlerTest {
   }
 
   @Test
-  fun testUpdateLocale_initialized_sameLocale_returnsFalse() {
-    val isUpdated = appLanguageLocaleHandler.updateLocale(computeNewAppLanguageLocale(ENGLISH))
+  fun testUpdateLocale_initialized_sameLocaleAsApp_returnsFalse() {
+    appLanguageLocaleHandler.updateLocale(computeNewAppLanguageLocale(ENGLISH))
+
+    val activityLanguageLocaleHandler = retrieveActivityLanguageLocaleHandler()
+    val isUpdated = activityLanguageLocaleHandler.updateLocale(computeNewAppLanguageLocale(ENGLISH))
+
     // The locale never changed, so there's nothing to update.
     assertThat(isUpdated).isFalse()
+  }
+
+  @Test
+  fun testUpdateLocale_initialized_differentLocaleFromApp_appChangedElsewhere_returnsTrue() {
+    appLanguageLocaleHandler.updateLocale(computeNewAppLanguageLocale(ENGLISH))
+    val activityLanguageLocaleHandler = retrieveActivityLanguageLocaleHandler()
+    appLanguageLocaleHandler.updateLocale(computeNewAppLanguageLocale(BRAZILIAN_PORTUGUESE))
+
+    val isUpdated =
+      activityLanguageLocaleHandler.updateLocale(computeNewAppLanguageLocale(BRAZILIAN_PORTUGUESE))
+
+    // Since the app language changed, the request to change the activity language should succeed.
+    // This ensures cases like a newer activity in the stack changing the language results in an
+    // older activity correctly being recreated due to it now having a new language configuration.
+    assertThat(isUpdated).isTrue()
   }
 
   @Test

--- a/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
@@ -326,10 +326,7 @@ class ActivityLanguageLocaleHandlerTest {
     fun inject(activityLanguageLocaleHandlerTest: ActivityLanguageLocaleHandlerTest)
   }
 
-  class TestApplication :
-    Application(),
-    ActivityComponentFactory,
-    ApplicationInjectorProvider {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerActivityLanguageLocaleHandlerTest_TestApplicationComponent.builder()
         .setApplication(this)

--- a/app/src/test/java/org/oppia/android/app/translation/AppLanguageWatcherMixinTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/AppLanguageWatcherMixinTest.kt
@@ -3,8 +3,8 @@ package org.oppia.android.app.translation
 import android.app.Application
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
@@ -74,6 +74,7 @@ import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.testing.junit.DefineAppLanguageLocaleContext
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
+import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -125,29 +126,15 @@ class AppLanguageWatcherMixinTest {
   //  cases when the locale isn't initialized (such as process death) prints an error & default
   //  initializes the locale handler.
 
-  @get:Rule
-  val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()
+  @get:Rule val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()
 
-  @get:Rule
-  var activityRule =
-    ActivityScenarioRule<TestActivity>(
-      TestActivity.createIntent(ApplicationProvider.getApplicationContext())
-    )
-
-  @Inject
-  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-
-  @Inject
-  lateinit var appLanguageLocaleHandler: AppLanguageLocaleHandler
-
-  @Inject
-  lateinit var testActivityRecreator: TestActivityRecreator
-
-  @Inject
-  lateinit var translationController: TranslationController
-
-  @Inject
-  lateinit var monitorFactory: DataProviderTestMonitor.Factory
+  @Inject lateinit var context: Context
+  @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
+  @Inject lateinit var appLanguageLocaleHandler: AppLanguageLocaleHandler
+  @Inject lateinit var testActivityRecreator: TestActivityRecreator
+  @Inject lateinit var translationController: TranslationController
+  @Inject lateinit var profileTestHelper: ProfileTestHelper
+  @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
   @Before
   fun setUp() {
@@ -156,91 +143,105 @@ class AppLanguageWatcherMixinTest {
 
   @Test
   fun testMixin_initialized_noAppLanguageChange_doesNothing() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = false)
-    testCoroutineDispatchers.runCurrent()
+    profileTestHelper.initializeProfiles()
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = false)
+      testCoroutineDispatchers.runCurrent()
 
-    // Initializing without anything changing should result in no changes to the locale or activity.
-    val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
-    assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
-    assertThat(testActivityRecreator.getRecreateCount()).isEqualTo(0)
+      // Initializing without anything changing should result in no changes to the locale or activity.
+      val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
+      assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+      assertThat(testActivityRecreator.getRecreateCount()).isEqualTo(0)
+    }
   }
 
   @Test
   fun testMixin_initialized_withAppLanguageChange_sameLanguage_localeIsUnchanged() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = false)
-    testCoroutineDispatchers.runCurrent()
+    profileTestHelper.initializeProfiles()
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = false)
+      testCoroutineDispatchers.runCurrent()
 
-    updateAppLanguageTo(ENGLISH)
+      updateAppLanguageTo(ENGLISH)
 
-    // Changing the app language to the current language shouldn't change the locale.
-    val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
-    assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+      // Changing the app language to the current language shouldn't change the locale.
+      val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
+      assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+    }
   }
 
   @Test
-  fun testMixin_initialized_withAppLanguageChange_newLanguage_shouldNotUpdateLocale() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = false)
-    testCoroutineDispatchers.runCurrent()
+  fun testMixin_initialized_withAppLanguageChange_newLanguage_updatesLocale() {
+    profileTestHelper.initializeProfiles()
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = false)
+      testCoroutineDispatchers.runCurrent()
 
-    updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
+      updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
 
-    // Changing to a new app language should not trigger the locale to change by the mixin
-    // since profileId is null in test scenario.
-    val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
-    assertThat(localeContext.languageDefinition.language).isNotEqualTo(BRAZILIAN_PORTUGUESE)
+      // Changing to a new app language should trigger the locale to change by the mixin.
+      val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
+      assertThat(localeContext.languageDefinition.language).isEqualTo(BRAZILIAN_PORTUGUESE)
+    }
   }
 
   @Test
   fun testMixin_initialized_withAppLanguageChange_sameLanguage_doesNotRecreateActivity() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = false)
-    testCoroutineDispatchers.runCurrent()
+    profileTestHelper.initializeProfiles()
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = false)
+      testCoroutineDispatchers.runCurrent()
 
-    updateAppLanguageTo(ENGLISH)
+      updateAppLanguageTo(ENGLISH)
 
-    // Changing the app language to the current language shouldn't recreate the activity.
-    assertThat(testActivityRecreator.getRecreateCount()).isEqualTo(0)
+      // Changing the app language to the current language shouldn't recreate the activity.
+      assertThat(testActivityRecreator.getRecreateCount()).isEqualTo(0)
+    }
   }
 
   @Test
-  fun testMixin_initialized_withAppLanguageChange_newLanguage_shouldNotRecreateActivity() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = false)
-    testCoroutineDispatchers.runCurrent()
+  fun testMixin_initialized_withAppLanguageChange_newLanguage_recreatesActivity() {
+    profileTestHelper.initializeProfiles()
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = false)
+      testCoroutineDispatchers.runCurrent()
 
-    updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
+      updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
 
-    // Changing to a new app language should not trigger the mixin to recreate the activity
-    // in test cases since profileId is null.
-    assertThat(testActivityRecreator.getRecreateCount()).isEqualTo(0)
+      // Changing to a new app language should trigger the mixin to recreate the activity.
+      assertThat(testActivityRecreator.getRecreateCount()).isEqualTo(1)
+    }
   }
 
   @Test
   fun testMixin_initialized_withShouldUseSystemLanguage_initializesSystemLanguage() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = true)
-    testCoroutineDispatchers.runCurrent()
+    profileTestHelper.initializeProfiles()
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = true)
+      testCoroutineDispatchers.runCurrent()
 
-    updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
+      updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
 
-    val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
-    assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+      // The system language (English by default) should be used even though the app language was
+      // requested to be changed since that's what the mixin was initialized to do.
+      val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
+      assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+    }
   }
 
   @Test
-  fun testMixin_initialized_withoutShouldUseSystemLanguage_initializesSystemLanguage() {
-    val mixin = retrieveAppLanguageWatcherMixin()
-    mixin.initialize(shouldOnlyUseSystemLanguage = false)
-    testCoroutineDispatchers.runCurrent()
+  fun testMixin_initialized_noProfileLoggedIn_initializesSystemLanguage() {
+    runAlongsideTestActivity { mixin ->
+      mixin.initialize(shouldOnlyUseSystemLanguage = true)
+      testCoroutineDispatchers.runCurrent()
 
-    updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
+      updateAppLanguageTo(BRAZILIAN_PORTUGUESE)
 
-    // Should return system language since profileId is null in test scenario
-    val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
-    assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+      // If there's no profile logged in, the language should stay as the system language even
+      // though it was requested to be changed.
+      val localeContext = appLanguageLocaleHandler.getDisplayLocale().localeContext
+      assertThat(localeContext.languageDefinition.language).isEqualTo(ENGLISH)
+    }
   }
 
   private fun updateAppLanguageTo(language: OppiaLanguage) {
@@ -254,12 +255,19 @@ class AppLanguageWatcherMixinTest {
     monitorFactory.waitForNextSuccessfulResult(updateProvider)
   }
 
-  private fun retrieveAppLanguageWatcherMixin(): AppLanguageWatcherMixin {
-    lateinit var mixin: AppLanguageWatcherMixin
-    activityRule.scenario.onActivity { activity ->
-      mixin = activity.appLanguageWatcherMixin
+  private fun launchTestActivity(): ActivityScenario<TestActivity> {
+    // All tests in this suite self-manage the mixin, so disable the one TestActivity uses to avoid
+    // clashes in behavior.
+    TestActivity.forceDisableLanguageWatcherMixinInitialization = true
+    return ActivityScenario.launch(TestActivity.createIntent(context))
+  }
+
+  private fun runAlongsideTestActivity(block: (AppLanguageWatcherMixin) -> Unit) {
+    launchTestActivity().use { scenario ->
+      lateinit var mixin: AppLanguageWatcherMixin
+      scenario.onActivity { activity -> mixin = activity.appLanguageWatcherMixin }
+      block(mixin)
     }
-    return mixin
   }
 
   private fun setUpTestApplicationComponent() {

--- a/data/src/main/java/org/oppia/android/data/backends/gae/Constants.kt
+++ b/data/src/main/java/org/oppia/android/data/backends/gae/Constants.kt
@@ -1,8 +1,8 @@
 package org.oppia.android.data.backends.gae
 
-/** An object that contains constants for data module */
+/** An object that contains constants for data module. */
 object Constants {
 
-  /** Constant which defines successful API call */
+  /** Constant which defines successful API call. */
   const val HTTP_OK = 200
 }

--- a/data/src/main/java/org/oppia/android/data/backends/gae/model/GaeFeedbackReportingEntryPoint.kt
+++ b/data/src/main/java/org/oppia/android/data/backends/gae/model/GaeFeedbackReportingEntryPoint.kt
@@ -10,7 +10,7 @@ data class GaeFeedbackReportingEntryPoint(
 
   /** Corresponds to a location in the app that a user can access feedback reporting. */
   @Json(name = "entry_point_name") val entryPointName: String,
-  /** Corresponds to the topic ID if the entry point is from a lesson or revision session */
+  /** Corresponds to the topic ID if the entry point is from a lesson or revision session. */
   @Json(name = "topic_id") val topicId: String?,
   /** Corresponds to the subtopic ID if the entry point is from a lesson. */
   @Json(name = "story_id") val storyId: String?,

--- a/data/src/main/java/org/oppia/android/data/backends/gae/model/GaeTopic.kt
+++ b/data/src/main/java/org/oppia/android/data/backends/gae/model/GaeTopic.kt
@@ -16,7 +16,7 @@ data class GaeTopic(
   @Json(name = "additional_story_dicts") val additionalStoryDicts: List<GaeStorySummary?>?,
   /** A map of skill descriptions keyed by skill ID. */
   @Json(name = "skill_descriptions") val skillDescriptions: Map<String, String?>?,
-  /** degrees_of_mastery map has skill id as key and a float value */
+  /** degrees_of_mastery map has skill id as key and a float value. */
   /** A map of degree masteries keyed by skill ID. */
   @Json(name = "degrees_of_mastery") val degreesOfMastery: Map<String, Float?>?,
   @Json(name = "uncategorized_skill_ids") val uncategorizedSkillIds: List<String?>?,

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintsAndSolutionConfigAlphaKenyaModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintsAndSolutionConfigAlphaKenyaModule.kt
@@ -4,7 +4,7 @@ import dagger.Module
 import dagger.Provides
 import java.util.concurrent.TimeUnit
 
-/** Production module for providing configurations for hints & solutions */
+/** Production module for providing configurations for hints & solutions. */
 @Module
 class HintsAndSolutionConfigAlphaKenyaModule {
   @Provides

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintsAndSolutionConfigFastShowTestModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintsAndSolutionConfigFastShowTestModule.kt
@@ -3,7 +3,7 @@ package org.oppia.android.domain.hintsandsolution
 import dagger.Module
 import dagger.Provides
 
-/** Test-only module for providing configurations to quickly reveal hints & solutions */
+/** Test-only module for providing configurations to quickly reveal hints & solutions. */
 @Module
 class HintsAndSolutionConfigFastShowTestModule {
   @Provides

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintsAndSolutionConfigModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintsAndSolutionConfigModule.kt
@@ -4,7 +4,7 @@ import dagger.Module
 import dagger.Provides
 import java.util.concurrent.TimeUnit
 
-/** Production module for providing configurations for hints & solutions */
+/** Production module for providing configurations for hints & solutions. */
 @Module
 class HintsAndSolutionConfigModule {
   @Provides

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/OppiaLogger.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/OppiaLogger.kt
@@ -7,66 +7,66 @@ import javax.inject.Inject
 
 /** Logger that handles general-purpose logging throughout the domain & UI layers. */
 class OppiaLogger @Inject constructor(private val consoleLogger: ConsoleLogger) {
-  /** Logs a verbose message with the specified tag. See [ConsoleLogger.v] for more context */
+  /** Logs a verbose message with the specified tag. See [ConsoleLogger.v] for more context. */
   fun v(tag: String, msg: String) {
     consoleLogger.v(tag, msg)
   }
 
   /**
    * Logs a verbose message with the specified tag, message and exception. See [ConsoleLogger.v]
-   * for more context
+   * for more context.
    */
   fun v(tag: String, msg: String, tr: Throwable) {
     consoleLogger.v(tag, msg, tr)
   }
 
-  /** Logs a debug message with the specified tag. See [ConsoleLogger.d] for more context */
+  /** Logs a debug message with the specified tag. See [ConsoleLogger.d] for more context. */
   fun d(tag: String, msg: String) {
     consoleLogger.d(tag, msg)
   }
 
   /**
    * Logs a debug message with the specified tag, message and exception. See [ConsoleLogger.d] for
-   * more context
+   * more context.
    */
   fun d(tag: String, msg: String, tr: Throwable) {
     consoleLogger.d(tag, msg, tr)
   }
 
-  /** Logs an info message with the specified tag. See [ConsoleLogger.i] for more context */
+  /** Logs an info message with the specified tag. See [ConsoleLogger.i] for more context. */
   fun i(tag: String, msg: String) {
     consoleLogger.i(tag, msg)
   }
 
   /**
    * Logs an info message with the specified tag, message and exception. See [ConsoleLogger.i] for
-   * more context
+   * more context.
    */
   fun i(tag: String, msg: String, tr: Throwable) {
     consoleLogger.i(tag, msg, tr)
   }
 
-  /** Logs a warn message with the specified tag. See [ConsoleLogger.w] for more context */
+  /** Logs a warn message with the specified tag. See [ConsoleLogger.w] for more context. */
   fun w(tag: String, msg: String) {
     consoleLogger.w(tag, msg)
   }
 
   /**
    * Logs a warn message with the specified tag, message and exception. See [ConsoleLogger.w] for
-   * more context
+   * more context.
    */
   fun w(tag: String, msg: String, tr: Throwable) {
     consoleLogger.w(tag, msg, tr)
   }
 
-  /** Logs an error message with the specified tag. See [ConsoleLogger.e] for more context */
+  /** Logs an error message with the specified tag. See [ConsoleLogger.e] for more context. */
   fun e(tag: String, msg: String) {
     consoleLogger.e(tag, msg)
   }
 
   /**
    * Logs an error message with the specified tag, message and exception. See [ConsoleLogger.e] for
-   * more context
+   * more context.
    */
   fun e(tag: String, msg: String, tr: Throwable?) {
     consoleLogger.e(tag, msg, tr)
@@ -77,7 +77,9 @@ class OppiaLogger @Inject constructor(private val consoleLogger: ConsoleLogger) 
     return EventLog.Context.newBuilder().setOpenHome(true).build()
   }
 
-  /** Returns the context of the event indicating that the user opened the profile chooser activity. */
+  /**
+   * Returns the context of the event indicating that the user opened the profile chooser activity.
+   */
   fun createOpenProfileChooserContext(): EventLog.Context {
     return EventLog.Context.newBuilder().setOpenProfileChooser(true).build()
   }

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/exceptions/UncaughtExceptionLoggerModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/exceptions/UncaughtExceptionLoggerModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dagger.multibindings.IntoSet
 import org.oppia.android.domain.oppialogger.ApplicationStartupListener
 
-/** Binds [UncaughtExceptionLoggerStartupListener] as an [ApplicationStartupListener] */
+/** Binds [UncaughtExceptionLoggerStartupListener] as an [ApplicationStartupListener]. */
 @Module
 interface UncaughtExceptionLoggerModule {
 

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
@@ -92,7 +92,9 @@ class PlatformParameterSyncUpWorker private constructor(
     }
   }
 
-  /** Synchronously executes the network request to get platform parameters from the Oppia backend */
+  /**
+   * Synchronously executes the network request to get platform parameters from the Oppia backend.
+   */
   private fun makeNetworkCallForPlatformParameters(): Optional<Response<Map<String, Any>>?> {
     return platformParameterService.transform { service ->
       service?.getPlatformParametersByVersion(
@@ -101,7 +103,7 @@ class PlatformParameterSyncUpWorker private constructor(
     }
   }
 
-  /** Extracts platform parameters from the remote service and stores them in the cache store */
+  /** Extracts platform parameters from the remote service and stores them in the cache store. */
   private suspend fun refreshPlatformParameters(): Result {
     return try {
       val optionalResponse = makeNetworkCallForPlatformParameters()

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -144,9 +144,8 @@ class TranslationController @Inject constructor(
    * Note that providing the returned selection to [updateAppLanguage] should result in no change to
    * the underlying configured selection.
    */
-  fun getAppLanguageSelection(profileId: ProfileId): DataProvider<AppLanguageSelection> {
-    return retrieveLanguageContentCacheStore(profileId)
-  }
+  fun getAppLanguageSelection(profileId: ProfileId): DataProvider<AppLanguageSelection> =
+    retrieveLanguageContentCacheStore(profileId)
 
   /**
    * Updates the language to be used by the specified user for app string translations. Note that
@@ -157,22 +156,17 @@ class TranslationController @Inject constructor(
    * best-effort basis for translating strings for system languages (generally if the system
    * language matches a supported language, otherwise the app defaults to English).
    *
-   * @return a [DataProvider] which succeeds only if the update succeeds, otherwise fails
-   * . The payload of the data provider is the *current* selection
-   *     state.
+   * @return a [DataProvider] which succeeds only if the update succeeds, otherwise fails. The
+   *     payload of the data provider is the *current* selection state.
    */
   fun updateAppLanguage(
     profileId: ProfileId,
     selection: AppLanguageSelection
   ): DataProvider<AppLanguageSelection> {
     val cacheStore = retrieveLanguageContentCacheStore(profileId)
-    val deferred = cacheStore.storeDataAsync(updateInMemoryCache = true) {
-      selection
-    }
+    val deferred = cacheStore.storeDataAsync(updateInMemoryCache = true) { selection }
 
-    return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_APP_LANGUAGE_DATA_PROVIDER_ID
-    ) {
+    return dataProviders.createInMemoryDataProviderAsync(UPDATE_APP_LANGUAGE_DATA_PROVIDER_ID) {
       deferred.await()
       AsyncResult.Success(cacheStore.readDataAsync().await())
     }

--- a/domain/src/main/java/org/oppia/android/domain/util/JsonAssetRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/util/JsonAssetRetriever.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 /** Utility that retrieves JSON assets and converts them to JSON objects. */
 class JsonAssetRetriever @Inject constructor(private val assetRepository: AssetRepository) {
 
-  /** Loads the JSON string from an asset and converts it to a JSONObject */
+  /** Loads the JSON string from an asset and converts it to a JSONObject. */
   fun loadJsonFromAsset(assetName: String): JSONObject? {
     return JSONObject(assetRepository.loadTextFileFromLocalAssets(assetName))
   }

--- a/model/src/main/proto/arguments.proto
+++ b/model/src/main/proto/arguments.proto
@@ -298,12 +298,6 @@ message AppLanguageActivityParams {
   OppiaLanguage oppia_language = 1;
 }
 
-// The bundle of properties that are returned by AppLanguageActivity after it's finished.
-message AppLanguageActivityResultBundle {
-  // The new default app language selected by the user.
-  OppiaLanguage oppia_language = 1;
-}
-
 // The bundle of properties that are saved upon configuration changes in AppLanguageActivity.
 message AppLanguageActivityStateBundle {
   // The default app language selected by the user.

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -334,7 +334,7 @@ file_content_checks {
   exempted_file_patterns: "testing/src/main/java/org/oppia/android/testing/junit/.+?\\.kt"
 }
 file_content_checks {
-  file_path_regex: ".+?.kt"
+  file_path_regex: ".+?\\.kt$"
   prohibited_content_regex: "android\\.content\\.ClipboardManager"
   failure_message: "Don't use Android's ClipboardManager directly. Instead, use ClipboardController."
   exempted_file_name: "app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt"
@@ -433,14 +433,14 @@ file_content_checks {
   required_content_regex: "decorateWithScreenName\\("
 }
 file_content_checks {
-  file_path_regex: ".+?.kt"
+  file_path_regex: ".+?\\.kt$"
   prohibited_content_regex: "WorkManager.getInstance"
   failure_message: "Use AnalyticsStartupListener to retrieve an instance of WorkManager rather than fetching one using getInstance (as the latter may create a WorkManager if one isn't already present, and the application may intend to disable it)."
   exempted_file_name: "app/src/main/java/org/oppia/android/app/application/AbstractOppiaApplication.kt"
   exempted_file_patterns: ".+?Test\\.kt"
 }
 file_content_checks {
-  file_path_regex: ".+?.kt"
+  file_path_regex: ".+?\\.kt$"
   prohibited_content_regex: ".+?\\.(post|postDelayed)[\\s]*(\\(|\\{).*?"
   failure_message: "Prefer avoiding post() and postDelayed() methods as they can can lead to subtle and difficult-to-debug crashes. Prefer using LifecycleSafeTimerFactory for most cases when an operation needs to run at a future time. For cases when state needs to be synchronized with a view, use doOnPreDraw or doOnLayout instead. For more context on the underlying issue, see: https://betterprogramming.pub/stop-using-post-postdelayed-in-your-android-views-9d1c8eeaadf2."
   exempted_file_name: "app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt"
@@ -449,4 +449,52 @@ file_content_checks {
   exempted_file_name: "app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt"
   exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
   exempted_file_name: "utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\/\\*\\*[^\\*\\/]+?$"
+  failure_message: "Badly formatted KDoc. KDocs should either fit entirely on one line, e.g. \"/** My KDoc. */\" or on multiple lines with the \"/**\" by itself. See other KDocs in the codebase for references."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\/\\*\\*[^\\s].+?\\*\\/$"
+  failure_message: "Badly formatted KDoc. Single-line KDocs should have one space after the \"/**\" and no other characters."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\/\\*\\*\\s{2,}.+?\\*\\/$"
+  failure_message: "Badly formatted KDoc. Single-line KDocs should have exactly one space after the \"/**\"."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\/\\*\\*.+?[^\\s]\\*\\/$"
+  failure_message: "Badly formatted KDoc. Single-line KDocs should always end with a single space before the final \"*/\"."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\/\\*\\*.+?\\s{2,}\\*\\/$"
+  failure_message: "Badly formatted KDoc. Single-line KDocs should always end with exactly one space before the final \"*/\"."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\*\\*/"
+  failure_message: "Badly formatted KDoc or block comment. KDocs and block comments should only end with \"*/\"."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "@(param|property)\\s+\\["
+  failure_message: "Badly formatted KDoc param or property at-clause: the name of the parameter or property should immediately follow the at-clause without any additional linking with brackets."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  file_path_regex: ".+?\\.kt$"
+  prohibited_content_regex: "\\/\\*\\*[^\\*\\/]+?[^\\.\\s]\\s*\\*\\/$"
+  failure_message: "Badly formatted KDoc. Single-line KDocs should end with punctuation."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/docs/KdocValidityCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/docs/KdocValidityCheckTest.kt
@@ -45,7 +45,7 @@ class KdocValidityCheckTest {
   fun testKdoc_function_withKdoc_checkShouldPass() {
     val testContent =
       """
-      /** 
+      /**
        * Returns the string corresponding to this error's string resources, or null if there 
        * is none.
        */

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -185,6 +185,28 @@ class RegexPatternValidationCheckTest {
       "with a view, use doOnPreDraw or doOnLayout instead. For more context on the underlying " +
       "issue, see: https://betterprogramming.pub/stop-using-post-postdelayed-in-your" +
       "-android-views-9d1c8eeaadf2."
+  private val badKdocShouldFitOnOneLine =
+    "Badly formatted KDoc. KDocs should either fit entirely on one line, e.g. \"/** My KDoc. */\"" +
+      " or on multiple lines with the \"/**\" by itself. See other KDocs in the codebase for" +
+      " references."
+  private val badSingleLineKdocShouldHaveSpacesAfterOpening =
+    "Badly formatted KDoc. Single-line KDocs should have one space after the \"/**\" and no other" +
+      " characters."
+  private val badSingleLineKdocShouldHaveExactlyOneSpaceAfterOpening =
+    "Badly formatted KDoc. Single-line KDocs should have exactly one space after the \"/**\"."
+  private val badSingleLineKdocShouldHaveSpacesBeforeEnding =
+    "Badly formatted KDoc. Single-line KDocs should always end with a single space before the" +
+      " final \"*/\"."
+  private val badSingleLineKdocShouldHaveExactlyOneSpaceBeforeEnding =
+    "Badly formatted KDoc. Single-line KDocs should always end with exactly one space before the" +
+      " final \"*/\"."
+  private val badKdocOrBlockCommentShouldEndWithCorrectEnding =
+    "Badly formatted KDoc or block comment. KDocs and block comments should only end with \"*/\"."
+  private val badKdocParamsAndPropertiesShouldHaveNameFollowing =
+    "Badly formatted KDoc param or property at-clause: the name of the parameter or property" +
+      " should immediately follow the at-clause without any additional linking with brackets."
+  private val badSingleLineKdocShouldEndWithPunctuation =
+    "Badly formatted KDoc. Single-line KDocs should end with punctuation."
   private val wikiReferenceNote =
     "Refer to https://github.com/oppia/oppia-android/wiki/Static-Analysis-Checks" +
       "#regexpatternvalidation-check for more details on how to fix this."
@@ -2555,6 +2577,209 @@ class RegexPatternValidationCheckTest {
       .isEqualTo(
         """
         $stringFilePath:1: $doesNotUsePostOrPostDelayed
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_kdocNotFittingLineFormatting_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /** Content here.
+         */
+        /** Correct KDoc. */
+        /**
+         * Correct KDoc.
+         */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $badKdocShouldFitOnOneLine
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_singleLineKdocWithExtraCharactersAfterStart_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /**Content here. */
+        /*** Content here. */
+        /** Correct KDoc. */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $badSingleLineKdocShouldHaveSpacesAfterOpening
+        $stringFilePath:2: $badSingleLineKdocShouldHaveSpacesAfterOpening
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_singleLineKdocWithExtraSpacesAfterStart_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /**  Content here. */
+        /**   Content here. */
+        /** Correct KDoc. */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $badSingleLineKdocShouldHaveExactlyOneSpaceAfterOpening
+        $stringFilePath:2: $badSingleLineKdocShouldHaveExactlyOneSpaceAfterOpening
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_multipleCommentTypesWithExtraCharactersBeforeEnd_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /** Content here.*/
+        /** Content here. **/
+        /** Correct KDoc. */
+        
+        /*
+         * Incorrect block comment.
+         **/
+        /*
+         * Correct block comment.
+         */
+        /**
+         * Incorrect KDoc comment.
+         **/
+        /**
+         * Correct KDoc comment.
+         */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    // Two patterns are combined in this check because they slightly overlap in affected cases (e.g.
+    // line 2 fails due to three different checks), and one pattern is subequently needed for the
+    // test to pass (punctuation).
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $badSingleLineKdocShouldHaveSpacesBeforeEnding
+        $stringFilePath:2: $badSingleLineKdocShouldHaveSpacesBeforeEnding
+        $stringFilePath:2: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+        $stringFilePath:7: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+        $stringFilePath:13: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+        $stringFilePath:2: $badSingleLineKdocShouldEndWithPunctuation
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_singleLineKdocWithExtraSpacesBeforeEnd_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /** Content here.  */
+        /** Content here.   */
+        /** Correct KDoc. */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $badSingleLineKdocShouldHaveExactlyOneSpaceBeforeEnding
+        $stringFilePath:2: $badSingleLineKdocShouldHaveExactlyOneSpaceBeforeEnding
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_kdocWithPropertiesAndParameters_withLinksAfter_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /**
+         * Summary fragment.
+         *
+         * @property [invalid] and explanation
+         * @property valid and explanation
+         * @param [invalid] and explanation
+         * @param valid and explanation
+         */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:4: $badKdocParamsAndPropertiesShouldHaveNameFollowing
+        $stringFilePath:6: $badKdocParamsAndPropertiesShouldHaveNameFollowing
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_singleLineKdocDoesNotEndWithPunctuation_fileContentIsNotCorrect() {
+    val prohibitedContent =
+      """
+        /** Content here */
+        /** Correct KDoc. */
+        /** Correct KDoc! */
+      """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) { runScript() }
+
+    // 'Punctuation' currently assumes a period.
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $badSingleLineKdocShouldEndWithPunctuation
+        $stringFilePath:3: $badSingleLineKdocShouldEndWithPunctuation
         $wikiReferenceNote
         """.trimIndent()
       )

--- a/testing/src/main/java/org/oppia/android/testing/FakeAnalyticsEventLogger.kt
+++ b/testing/src/main/java/org/oppia/android/testing/FakeAnalyticsEventLogger.kt
@@ -6,7 +6,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**  A test specific fake for the event logger. */
+/** A test specific fake for the event logger. */
 @Singleton
 class FakeAnalyticsEventLogger @Inject constructor() : AnalyticsEventLogger {
   private val eventList = CopyOnWriteArrayList<EventLog>()

--- a/testing/src/main/java/org/oppia/android/testing/network/MockPlatformParameterService.kt
+++ b/testing/src/main/java/org/oppia/android/testing/network/MockPlatformParameterService.kt
@@ -20,11 +20,11 @@ class MockPlatformParameterService(
   private val TEST_UNSUPPORTED_OBJECT_AS_PARAM_VALUE = listOf<String>()
 
   companion object {
-    /** Mock app version which is used to get right response from [MockPlatformParameterService] */
+    /** Mock app version which is used to get right response from [MockPlatformParameterService]. */
     const val appVersionForCorrectResponse = "1.0"
-    /** Mock app version which is used to get wrong response from [MockPlatformParameterService] */
+    /** Mock app version which is used to get wrong response from [MockPlatformParameterService]. */
     const val appVersionForWrongResponse = "2.0"
-    /** Mock app version which is used to get empty response from [MockPlatformParameterService] */
+    /** Mock app version which is used to get empty response from [MockPlatformParameterService]. */
     const val appVersionForEmptyResponse = "3.0"
   }
 

--- a/testing/src/main/java/org/oppia/android/testing/profile/ProfileTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/profile/ProfileTestHelper.kt
@@ -1,107 +1,79 @@
 package org.oppia.android.testing.profile
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
-import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 /** This helper allows tests to easily create new profiles and switch between them. */
 class ProfileTestHelper @Inject constructor(
   private val profileManagementController: ProfileManagementController,
-  private val testCoroutineDispatchers: TestCoroutineDispatchers,
   private val monitorFactory: DataProviderTestMonitor.Factory
 ) {
-
-  private val observer = Observer<AsyncResult<Any?>> { }
-
   /**
-   * Creates one admin profile and one user profile. Logs in to admin profile.
+   * Creates an assortment of non-admin profiles, and an admin profile. May optionally automatically
+   * log into the newly created admin profile.
    *
-   * @returns a [LiveData] that indicates when the login is complete.
-   * Note that this if is not observed, the login will not be performed.
+   * @param autoLogIn whether to automatically log in the admin profile
+   * @returns the [AsyncResult] designating the result of attempting to log into the admin profile
    */
-  fun initializeProfiles(): LiveData<AsyncResult<Any?>> {
-    profileManagementController.addProfile(
+  fun initializeProfiles(autoLogIn: Boolean = true): AsyncResult<Any?> {
+    addProfileAndWait(
       name = "Admin",
       pin = "12345",
-      avatarImagePath = null,
       allowDownloadAccess = true,
-      colorRgb = -10710042,
       isAdmin = true
     )
-    profileManagementController.addProfile(
+    addProfileAndWait(
       name = "Ben",
       pin = "123",
-      avatarImagePath = null,
       allowDownloadAccess = false,
-      colorRgb = -10710042,
       isAdmin = false
     )
-    profileManagementController.addProfile(
+    addProfileAndWait(
       name = "Nikita",
       pin = "123",
-      avatarImagePath = null,
       allowDownloadAccess = false,
-      colorRgb = -10710042,
       isAdmin = false
     )
-    profileManagementController.addProfile(
+    val lastAddResult = addProfileAndWait(
       name = "Natrajan Subramanniyam Balaguruswamy",
       pin = "123",
-      avatarImagePath = null,
       allowDownloadAccess = false,
-      colorRgb = -10710042,
       isAdmin = false
     )
-    val result = profileManagementController.loginToProfile(
-      ProfileId.newBuilder().setInternalId(0)
-        .build()
-    ).toLiveData()
-    testCoroutineDispatchers.runCurrent()
-    return result
+    return if (autoLogIn) {
+      monitorFactory.createMonitor(logIntoAdmin()).waitForNextResult()
+    } else lastAddResult
   }
 
   /**
    * Creates one admin profile and logs in to admin profile.
    *
-   * @returns a [LiveData] that indicates when the login is complete.
-   * Note that this if is not observed, the login will not be performed.
+   * @returns the [AsyncResult] designating the result of attempting to log into the admin profile
    */
-  fun addOnlyAdminProfile(): LiveData<AsyncResult<Any?>> {
-    profileManagementController.addProfile(
+  fun addOnlyAdminProfile(): AsyncResult<Any?> {
+    addProfileAndWait(
       name = "Admin",
       pin = "12345",
-      avatarImagePath = null,
       allowDownloadAccess = true,
-      colorRgb = -10710042,
       isAdmin = true
-    ).toLiveData()
-    val result = profileManagementController.loginToProfile(
-      ProfileId.newBuilder().setInternalId(0).build()
-    ).toLiveData()
-    testCoroutineDispatchers.runCurrent()
-    return result
+    )
+    return monitorFactory.createMonitor(logIntoAdmin()).waitForNextResult()
   }
 
   /** Create [numProfiles] number of user profiles. */
   fun addMoreProfiles(numProfiles: Int) {
     for (x in 0 until numProfiles) {
-      profileManagementController.addProfile(
+      addProfileAndWait(
         name = (x + 65).toChar().toString(),
         pin = "123",
-        avatarImagePath = null,
         allowDownloadAccess = false,
-        colorRgb = -10710042,
         isAdmin = false
       )
     }
-    testCoroutineDispatchers.runCurrent()
   }
 
   /** Log in to admin profile. */
@@ -129,14 +101,16 @@ class ProfileTestHelper @Inject constructor(
     ).isContinueButtonAnimationSeen
   }
 
-  /**
-   * While performing any action based on the LiveData (see other methods above),
-   * this helper function should be used to ensure the operation corresponding to the LiveData
-   * properly completes.
-   *
-   * @param data is the LiveData which needs to accessed while performing action.
-   */
-  fun waitForOperationToComplete(data: LiveData<AsyncResult<Any?>>) {
-    data.observeForever(observer)
+  private fun addProfileAndWait(
+    name: String,
+    pin: String,
+    allowDownloadAccess: Boolean,
+    isAdmin: Boolean
+  ): AsyncResult<Any?> {
+    val addResult =
+      profileManagementController.addProfile(
+        name, pin, avatarImagePath = null, allowDownloadAccess, colorRgb = -10710042, isAdmin
+      )
+    return monitorFactory.createMonitor(addResult).waitForNextResult()
   }
 }

--- a/testing/src/test/java/org/oppia/android/testing/profile/ProfileTestHelperTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/profile/ProfileTestHelperTest.kt
@@ -2,7 +2,6 @@ package org.oppia.android.testing.profile
 
 import android.app.Application
 import android.content.Context
-import androidx.lifecycle.Observer
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -11,16 +10,8 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
-import org.mockito.Mock
-import org.mockito.Mockito.atLeastOnce
-import org.mockito.Mockito.verify
-import org.mockito.junit.MockitoJUnit
-import org.mockito.junit.MockitoRule
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.domain.oppialogger.LoggingIdentifierModule
 import org.oppia.android.domain.oppialogger.analytics.ApplicationLifecycleModule
@@ -35,7 +26,6 @@ import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.caching.AssetModule
-import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvidersInjector
 import org.oppia.android.util.data.DataProvidersInjectorProvider
 import org.oppia.android.util.locale.LocaleProdModule
@@ -57,17 +47,11 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = ProfileTestHelperTest.TestApplication::class)
 class ProfileTestHelperTest {
-  @field:[Rule JvmField] val mockitoRule: MockitoRule = MockitoJUnit.rule()
-
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var profileManagementController: ProfileManagementController
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
-
-  @Mock lateinit var mockUpdateResultObserver: Observer<AsyncResult<Any?>>
-
-  @Captor lateinit var updateResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
 
   @Before
   fun setUp() {
@@ -80,12 +64,11 @@ class ProfileTestHelperTest {
 
   @Test
   fun testInitializeProfiles_initializeProfiles_checkProfilesAreAddedAndCurrentIsSet() {
-    profileTestHelper.initializeProfiles().observeForever(mockUpdateResultObserver)
+    val initializationResult = profileTestHelper.initializeProfiles()
     val profilesProvider = profileManagementController.getProfiles()
     testCoroutineDispatchers.runCurrent()
 
-    verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
-    assertThat(updateResultCaptor.value).isSuccess()
+    assertThat(initializationResult).isSuccess()
     val profiles = monitorFactory.waitForNextSuccessfulResult(profilesProvider)
     assertThat(profiles[0].name).isEqualTo("Admin")
     assertThat(profiles[0].isAdmin).isTrue()
@@ -96,12 +79,11 @@ class ProfileTestHelperTest {
 
   @Test
   fun testInitializeProfiles_addOnlyAdminProfile_checkProfileIsAddedAndCurrentIsSet() {
-    profileTestHelper.addOnlyAdminProfile().observeForever(mockUpdateResultObserver)
+    val initializationResult = profileTestHelper.addOnlyAdminProfile()
     val profilesProvider = profileManagementController.getProfiles()
     testCoroutineDispatchers.runCurrent()
 
-    verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
-    assertThat(updateResultCaptor.value).isSuccess()
+    assertThat(initializationResult).isSuccess()
     val profiles = monitorFactory.waitForNextSuccessfulResult(profilesProvider)
     assertThat(profiles.size).isEqualTo(1)
     assertThat(profiles[0].name).isEqualTo("Admin")

--- a/utility/src/main/java/org/oppia/android/util/logging/ConsoleLogger.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/ConsoleLogger.kt
@@ -24,52 +24,52 @@ class ConsoleLogger @Inject constructor(
   private val blockingScope = CoroutineScope(blockingDispatcher)
   private val logDirectory = File(context.filesDir, "oppia_app.log")
 
-  /** Logs a verbose message with the specified tag.*/
+  /** Logs a verbose message with the specified tag. */
   fun v(tag: String, msg: String) {
     writeLog(LogLevel.VERBOSE, tag, msg)
   }
 
-  /** Logs a verbose message with the specified tag, message and exception.*/
+  /** Logs a verbose message with the specified tag, message and exception. */
   fun v(tag: String, msg: String, tr: Throwable) {
     writeError(LogLevel.VERBOSE, tag, msg, tr)
   }
 
-  /** Logs a debug message with the specified tag*/
+  /** Logs a debug message with the specified tag. */
   fun d(tag: String, msg: String) {
     writeLog(LogLevel.DEBUG, tag, msg)
   }
 
-  /** Logs a debug message with the specified tag, message and exception.*/
+  /** Logs a debug message with the specified tag, message and exception. */
   fun d(tag: String, msg: String, tr: Throwable) {
     writeError(LogLevel.DEBUG, tag, msg, tr)
   }
 
-  /** Logs a info message with the specified tag.*/
+  /** Logs a info message with the specified tag. */
   fun i(tag: String, msg: String) {
     writeLog(LogLevel.INFO, tag, msg)
   }
 
-  /** Logs a info message with the specified tag, message and exception.*/
+  /** Logs a info message with the specified tag, message and exception. */
   fun i(tag: String, msg: String, tr: Throwable) {
     writeError(LogLevel.INFO, tag, msg, tr)
   }
 
-  /** Logs a warn message with the specified tag.*/
+  /** Logs a warn message with the specified tag. */
   fun w(tag: String, msg: String) {
     writeLog(LogLevel.WARNING, tag, msg)
   }
 
-  /** Logs a warn message with the specified tag, message and exception.*/
+  /** Logs a warn message with the specified tag, message and exception. */
   fun w(tag: String, msg: String, tr: Throwable) {
     writeError(LogLevel.WARNING, tag, msg, tr)
   }
 
-  /** Logs a error message with the specified tag.*/
+  /** Logs a error message with the specified tag. */
   fun e(tag: String, msg: String) {
     writeLog(LogLevel.ERROR, tag, msg)
   }
 
-  /** Logs a error message with the specified tag, message and exception.*/
+  /** Logs a error message with the specified tag, message and exception. */
   fun e(tag: String, msg: String, tr: Throwable?) {
     writeError(LogLevel.ERROR, tag, msg, tr)
   }

--- a/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
@@ -489,7 +489,7 @@ class EventBundleCreator @Inject constructor(
     }
   }
 
-  /*** Represents an [OppiaMetricLog] loggable metric (denoted by [LoggableMetricTypeCase]).*/
+  /** Represents an [OppiaMetricLog] loggable metric (denoted by [LoggableMetricTypeCase]). */
   private sealed class PerformanceMetricsLoggableMetricType<T>(
     val metricName: String,
     private val value: T

--- a/utility/src/main/java/org/oppia/android/util/logging/SyncStatusManagerImpl.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/SyncStatusManagerImpl.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
 private const val SYNC_STATUS_PROVIDER_ID = "SyncStatusManagerImpl.sync_status"
 private const val DEFAULT_EVENT_LOG_PROVIDER_ID = "SyncStatusManagerImpl.default_event_logs"
 
-/** Manager for handling the sync status of the device during log upload to the remote service.*/
+/** Manager for handling the sync status of the device during log upload to the remote service. */
 @Singleton
 class SyncStatusManagerImpl @Inject constructor(
   private val dataProviders: DataProviders,

--- a/utility/src/main/java/org/oppia/android/util/math/FloatExtensions.kt
+++ b/utility/src/main/java/org/oppia/android/util/math/FloatExtensions.kt
@@ -28,7 +28,8 @@ fun Float.isApproximatelyEqualTo(other: Float): Boolean {
   return abs(this - other) < FLOAT_EQUALITY_EPSILON
 }
 
-/** Returns whether this double approximately equals another based on a consistent epsilon value
+/**
+ * Returns whether this double approximately equals another based on a consistent epsilon value
  * ([DOUBLE_EQUALITY_EPSILON]).
  */
 fun Double.isApproximatelyEqualTo(other: Double): Boolean {

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -79,10 +79,9 @@ const val SYNC_UP_WORKER_TIME_PERIOD_IN_HOURS_DEFAULT_VALUE = 12
 @Qualifier
 annotation class EnableLanguageSelectionUi
 
-// TODO: Revert this.
 // TODO(#52): Enable this feature by default once it's completed.
 /** Default value for the feature flag corresponding to [EnableLanguageSelectionUi]. */
-const val ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE = true
+const val ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE = false
 
 /**
  * Qualifier for the feature flag corresponding to enabling the extra topic tabs: practice and info.

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -79,9 +79,10 @@ const val SYNC_UP_WORKER_TIME_PERIOD_IN_HOURS_DEFAULT_VALUE = 12
 @Qualifier
 annotation class EnableLanguageSelectionUi
 
+// TODO: Revert this.
 // TODO(#52): Enable this feature by default once it's completed.
 /** Default value for the feature flag corresponding to [EnableLanguageSelectionUi]. */
-const val ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE = false
+const val ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE = true
 
 /**
  * Qualifier for the feature flag corresponding to enabling the extra topic tabs: practice and info.


### PR DESCRIPTION
## Explanation
These changes intend to wrap up the remainder of work needed for #4762 to be merged, including:
1. Addressing all remaining KDoc and formatting concerns.
2. Finalizing the activity & app mixin tests.
3. Performing some manual testing to make sure everything is working correctly.
4. Clean up some of the view model logic in ``OptionControlsViewModel``.

Some additional  changes ended up happening as part of the above:
- Per (1), I went ahead and added a bunch of regex checks & tests to both have confidence that all styling issues were fixed, and that they can't be reintroduced by anyone else in the future. This required cleaning up a number of existing problems in KDocs elsewhere in the codebase.
- Per (2), I needed to update ``ProfileTestHelper`` to have more robust lifecycle management which, in turn, required some small changes to downstream tests. ``AppLanguageWatcherMixinTest`` also needed reworking in order to set up its ``TestActivity`` at the correct time (after profile creation). ``TestActivity`` needed to be updated to disable its own ``AppLanguageWatcherMixin`` so that ``AppLanguageWatcherMixinTest`` could test its mixin without interference.
- Per (3), I noticed there was a bug when using the language selector. It wouldn't actually save the selected language when back navigating using the toolbar, only when using the system back button (and, in fact, would always revert back to English). Upon digging, I realized this was because of an inconsistency in the activity result handling (the toolbar bit wasn't ever updated so a default result proto was the "result," and default moves the app back to using system language, or English in my case). Due to ``OptionControlsViewModel`` now depending on ``TranslationController`` directly, this result logic isn't even needed anymore so I went ahead and removed all of it. This is a cleanup that also results in back navigation working correctly for both the navigation bar and system back buttons.

I also noticed in a follow-up commit that tablet mode auto-selection for the reading text fragment stopped working. I think this incidentally worked before due to a very specific timing situation that occurred when fragment initialization raced against the dual LiveData observation that was happening. I removed this fragile mechanism which now breaks with the simpler single LiveData version of OptionControlsViewModel and replaced it with a more robust flow that happens during fragment creation. This could be further improved by accounting for the default selected fragment, but it's a good place to start.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [X] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A for time--any relevant changes should be included directly in #4762.